### PR TITLE
Offer option to resample to power of 2 in bandpass filter

### DIFF
--- a/simpa/utils/tags.py
+++ b/simpa/utils/tags.py
@@ -751,6 +751,14 @@ class Tags:
     Usage: adapter PyTorchDASAdapter
     """
 
+    RECONSTRUCTION_PERFORM_RESAMPLING_FOR_FFT = ("reconstruction_perform_resampling_for_fft",
+                                    (bool, np.bool, np.bool_))
+    """
+    Whether the data is resampled to a power of 2 in time dimension before applying the FFT 
+    and resampled back after filtering for performance reasons. Default should be False\n
+    Usage: adapter reconstruction_utils
+    """
+
     TUKEY_WINDOW_ALPHA = ("tukey_window_alpha", (int, np.integer, float))
     """
     Sets alpha value of Tukey window between 0 (similar to box window) and 1 (similar to Hann window).

--- a/simpa_tests/automatic_tests/test_bandpass_filter.py
+++ b/simpa_tests/automatic_tests/test_bandpass_filter.py
@@ -46,12 +46,16 @@ class TestBandpassFilter(unittest.TestCase):
                                                                               settings[Tags.RECONSTRUCTION_MODEL_SETTINGS],
                                                                               device)
 
+        filtered_time_series_with_resampling = bandpass_filtering(combined_time_series, 1e-3, int(11000), int(9000), 0, True)
+
         filtered_time_series = bandpass_filtering(combined_time_series, 1e-3, int(11000), int(9000), 0)
 
         # check if both bandpass filtering methods return the same result
         assert np.array_equal(filtered_time_series, filtered_time_series_with_settings)
 
         assert (np.abs(base_time_series - filtered_time_series) < 1e-5).all()
+
+        assert (np.abs(base_time_series - filtered_time_series_with_resampling) < 1e-1).all()
 
         if Visualize:
             labels = ["Base time series", "Low frequency time series", "High frequency time series",


### PR DESCRIPTION
Fixes issue #123 

In addition to the implemented additional option for resampling, we might also implement a way to specify the resampling method via Tags, e.g. linear vs. cubic interpolation, or which order of splines to be used.