### PR TITLE
Rounding fov also in cropping component, fixes #134

### DIFF
--- a/simpa/core/processing_components/monospectral/field_of_view_cropping.py
+++ b/simpa/core/processing_components/monospectral/field_of_view_cropping.py
@@ -47,7 +47,7 @@ class FieldOfViewCropping(ProcessingComponent):
         else:
             field_of_view_mm = device.get_field_of_view_mm()
         self.logger.debug(f"FOV (mm): {field_of_view_mm}")
-        field_of_view_voxels = (field_of_view_mm / self.global_settings[Tags.SPACING_MM]).astype(np.int32)
+        field_of_view_voxels = np.round(field_of_view_mm / self.global_settings[Tags.SPACING_MM]).astype(np.int32)
         self.logger.debug(f"FOV (voxels): {field_of_view_voxels}")
 
         # In case it should be cropped from A to A, then crop from A to A+1


### PR DESCRIPTION
Fixes the reopend issues #134 to make the field of view definition consistent in the cropping component with the device fov definition. In both cases the values are now rounded first before casting them as integers in order to obtain the closest integer value and not the smallest.