### PR TITLE
Check if key is set before accessing it

### DIFF
--- a/simpa/core/simulation_modules/reconstruction_module/reconstruction_utils.py
+++ b/simpa/core/simulation_modules/reconstruction_module/reconstruction_utils.py
@@ -63,10 +63,13 @@ def bandpass_filter_with_settings(data: np.ndarray, global_settings: Settings, c
         """
 
         # select corresponding filtering method depending on tag in settings
-        if component_settings[Tags.BANDPASS_FILTER_METHOD] == Tags.TUKEY_BANDPASS_FILTER:
-            return tukey_bandpass_filtering_with_settings(data, global_settings,component_settings, device)
-        elif component_settings[Tags.BANDPASS_FILTER_METHOD] == Tags.BUTTERWORTH_BANDPASS_FILTER:
-            return butter_bandpass_filtering_with_settings(data, global_settings,component_settings, device)
+        if Tags.BANDPASS_FILTER_METHOD in component_settings:
+            if component_settings[Tags.BANDPASS_FILTER_METHOD] == Tags.TUKEY_BANDPASS_FILTER:
+                return tukey_bandpass_filtering_with_settings(data, global_settings,component_settings, device)
+            elif component_settings[Tags.BANDPASS_FILTER_METHOD] == Tags.BUTTERWORTH_BANDPASS_FILTER:
+                return butter_bandpass_filtering_with_settings(data, global_settings,component_settings, device)
+            else:
+                return tukey_bandpass_filtering_with_settings(data, global_settings,component_settings, device)
         else:
             return tukey_bandpass_filtering_with_settings(data, global_settings,component_settings, device)
 


### PR DESCRIPTION
Fixes the issue described in #136 by checking if the tag is set in the settings first before accessing it. If it's not set, the default filtering method will be applied.