### PR TITLE
Implemented #144, partial volume via settings

### DIFF
--- a/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
+++ b/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
@@ -145,6 +145,11 @@ class MSOTAcuityEcho(PhotoacousticDevice):
                 structure_dict[Tags.STRUCTURE_END_MM][2] = structure_dict[Tags.STRUCTURE_END_MM][
                                                                2] + z_dim_position_shift_mm
 
+        if Tags.CONSIDER_PARTIAL_VOLUME_IN_DEVICE in volume_creator_settings:
+            consider_partial_volume = volume_creator_settings[Tags.CONSIDER_PARTIAL_VOLUME_IN_DEVICE]
+        else:
+            consider_partial_volume = False
+        
         if Tags.US_GEL in volume_creator_settings and volume_creator_settings[Tags.US_GEL]:
             us_gel_layer_settings = Settings({
                 Tags.PRIORITY: 5,
@@ -152,7 +157,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
                                           heavy_water_layer_height_mm + mediprene_layer_height_mm],
                 Tags.STRUCTURE_END_MM: [0, 0,
                                         heavy_water_layer_height_mm + mediprene_layer_height_mm + us_gel_thickness],
-                Tags.CONSIDER_PARTIAL_VOLUME: volume_creator_settings[Tags.CONSIDER_PARTIAL_VOLUME],
+                Tags.CONSIDER_PARTIAL_VOLUME: consider_partial_volume,
                 Tags.MOLECULE_COMPOSITION: TISSUE_LIBRARY.ultrasound_gel(),
                 Tags.STRUCTURE_TYPE: Tags.HORIZONTAL_LAYER_STRUCTURE
             })
@@ -163,7 +168,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
             Tags.PRIORITY: 5,
             Tags.STRUCTURE_START_MM: [0, 0, heavy_water_layer_height_mm],
             Tags.STRUCTURE_END_MM: [0, 0, heavy_water_layer_height_mm + mediprene_layer_height_mm],
-            Tags.CONSIDER_PARTIAL_VOLUME: volume_creator_settings[Tags.CONSIDER_PARTIAL_VOLUME],
+            Tags.CONSIDER_PARTIAL_VOLUME: consider_partial_volume,
             Tags.MOLECULE_COMPOSITION: TISSUE_LIBRARY.mediprene(),
             Tags.STRUCTURE_TYPE: Tags.HORIZONTAL_LAYER_STRUCTURE
         })

--- a/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
+++ b/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
@@ -152,7 +152,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
                                           heavy_water_layer_height_mm + mediprene_layer_height_mm],
                 Tags.STRUCTURE_END_MM: [0, 0,
                                         heavy_water_layer_height_mm + mediprene_layer_height_mm + us_gel_thickness],
-                Tags.CONSIDER_PARTIAL_VOLUME: True,
+                Tags.CONSIDER_PARTIAL_VOLUME: volume_creator_settings[Tags.CONSIDER_PARTIAL_VOLUME],
                 Tags.MOLECULE_COMPOSITION: TISSUE_LIBRARY.ultrasound_gel(),
                 Tags.STRUCTURE_TYPE: Tags.HORIZONTAL_LAYER_STRUCTURE
             })
@@ -163,7 +163,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
             Tags.PRIORITY: 5,
             Tags.STRUCTURE_START_MM: [0, 0, heavy_water_layer_height_mm],
             Tags.STRUCTURE_END_MM: [0, 0, heavy_water_layer_height_mm + mediprene_layer_height_mm],
-            Tags.CONSIDER_PARTIAL_VOLUME: True,
+            Tags.CONSIDER_PARTIAL_VOLUME: volume_creator_settings[Tags.CONSIDER_PARTIAL_VOLUME],
             Tags.MOLECULE_COMPOSITION: TISSUE_LIBRARY.mediprene(),
             Tags.STRUCTURE_TYPE: Tags.HORIZONTAL_LAYER_STRUCTURE
         })

--- a/simpa/utils/libraries/structure_library/StructureBase.py
+++ b/simpa/utils/libraries/structure_library/StructureBase.py
@@ -59,7 +59,9 @@ class GeometricalStructure:
         if Tags.PRIORITY in single_structure_settings:
             self.priority = single_structure_settings[Tags.PRIORITY]
 
-        self.partial_volume = single_structure_settings[Tags.CONSIDER_PARTIAL_VOLUME]
+        if Tags.CONSIDER_PARTIAL_VOLUME in single_structure_settings:
+            self.partial_volume = single_structure_settings[Tags.CONSIDER_PARTIAL_VOLUME]
+        else: self.partial_volume = False
 
         self.molecule_composition = single_structure_settings[Tags.MOLECULE_COMPOSITION]
         self.molecule_composition.update_internal_properties()

--- a/simpa/utils/libraries/structure_library/StructureBase.py
+++ b/simpa/utils/libraries/structure_library/StructureBase.py
@@ -61,7 +61,8 @@ class GeometricalStructure:
 
         if Tags.CONSIDER_PARTIAL_VOLUME in single_structure_settings:
             self.partial_volume = single_structure_settings[Tags.CONSIDER_PARTIAL_VOLUME]
-        else: self.partial_volume = False
+        else:
+            self.partial_volume = False
 
         self.molecule_composition = single_structure_settings[Tags.MOLECULE_COMPOSITION]
         self.molecule_composition.update_internal_properties()

--- a/simpa/utils/tags.py
+++ b/simpa/utils/tags.py
@@ -191,6 +191,12 @@ class Tags:
     If True, the structure will be generated with its edges only occupying a partial volume of the voxel.\n
     Usage: adapter versatile_volume_creation
     """
+    CONSIDER_PARTIAL_VOLUME_IN_DEVICE = ("consider_partial_volume_in_device", bool)
+    """
+    If True, the structures inside the device (i.e. US gel and membrane) will be generated with its edges
+    only occupying a partial volume of the voxel. \n
+    Usage: adapter versatile_volume_creation 
+    """
 
     STRUCTURE_START_MM = ("structure_start", (list, tuple, np.ndarray))
     """


### PR DESCRIPTION
I implemented #144. The partial volume effect within the device can now be adapted in the settings. The tag CONSIDER_PARTIAL_VOULME is now always necessary in the volume_creation_settings. 