### PR TITLE
Add version number in hdf5

### DIFF
--- a/simpa/core/simulation.py
+++ b/simpa/core/simulation.py
@@ -9,6 +9,7 @@ from simpa.utils.settings import Settings
 from simpa.log import Logger
 from .device_digital_twins.digital_device_twin_base import DigitalDeviceTwinBase
 
+from pathlib import Path
 import numpy as np
 import os
 import time
@@ -54,6 +55,11 @@ def simulate(simulation_pipeline: list, settings: Settings, digital_device_twin:
         simpa_output_path = path + settings[Tags.VOLUME_NAME]
 
     settings[Tags.SIMPA_OUTPUT_PATH] = simpa_output_path + ".hdf5"
+    
+    version_path = Path(__file__).parent / "../../VERSION"
+    with open(version_path, 'r') as readme_file:
+        version = readme_file.read()    
+    settings[Tags.SIMPA_VERSION] = version
 
     simpa_output[Tags.SETTINGS] = settings
     simpa_output[Tags.DIGITAL_DEVICE] = digital_device_twin

--- a/simpa/core/simulation.py
+++ b/simpa/core/simulation.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import numpy as np
 import os
 import time
+import pkg_resources
 
 
 def simulate(simulation_pipeline: list, settings: Settings, digital_device_twin: DigitalDeviceTwinBase):
@@ -54,12 +55,8 @@ def simulate(simulation_pipeline: list, settings: Settings, digital_device_twin:
     else:
         simpa_output_path = path + settings[Tags.VOLUME_NAME]
 
-    settings[Tags.SIMPA_OUTPUT_PATH] = simpa_output_path + ".hdf5"
-    
-    version_path = Path(__file__).parent / "../../VERSION"
-    with open(version_path, 'r') as readme_file:
-        version = readme_file.read()    
-    settings[Tags.SIMPA_VERSION] = version
+    settings[Tags.SIMPA_OUTPUT_PATH] = simpa_output_path + ".hdf5"    
+    settings[Tags.SIMPA_VERSION] = pkg_resources.require("simpa")[0].version 
 
     simpa_output[Tags.SETTINGS] = settings
     simpa_output[Tags.DIGITAL_DEVICE] = digital_device_twin

--- a/simpa/utils/tags.py
+++ b/simpa/utils/tags.py
@@ -1234,6 +1234,11 @@ class Tags:
     Default filename of the SIMPA output if not specified otherwise.\n
     Usage: SIMPA package, naming convention
     """
+    SIMPA_VERSION = ("simpa_version", str)
+    """
+    Version number of the currently installed simpa package
+    Usage: SIMPA package
+    """
 
     SETTINGS = "settings"
     """


### PR DESCRIPTION
I implemented a first version that includes the simpa version from the VERSION file to the final hdf5 in the settings dict (#146). However I am not sure whether is is the best way to implement it and the description of the corresponding tag might need adaption. 