### PR TITLE
Fixed detector positioning in msot acuity echo

### DIFF
--- a/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
+++ b/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
@@ -49,9 +49,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
         self.probe_height_mm = 43.2
         self.focus_in_field_of_view_mm = 8
         self.detection_geometry_position_vector = np.add(self.device_position_mm,
-                                                         np.array([0, 0,
-                                                                   self.probe_height_mm +
-                                                                   self.focus_in_field_of_view_mm]))
+                                                         np.array([0, 0, self.focus_in_field_of_view_mm]))
 
         if field_of_view_extent_mm is None:
             self.field_of_view_extent_mm = np.asarray([-(2 * np.sin(0.34 / 40 * 128) * 40) / 2,


### PR DESCRIPTION
Fix for detector geometry positioning. When the `device_position_mm` of the `MSOTAcuityEcho` is already defined at the outer side of the membrane, the center of the detector geometry is only `self.focus_in_field_of_view_mm` (8mm) further away from the membrane