### PR TITLE
T152 processing unit

### DIFF
--- a/simpa/core/simulation_modules/reconstruction_module/reconstruction_utils.py
+++ b/simpa/core/simulation_modules/reconstruction_module/reconstruction_utils.py
@@ -381,7 +381,10 @@ def preparing_reconstruction_and_obtaining_reconstruction_settings(
         'The time series sensor data must have been converted to a tensor'
 
     # move tensors to GPU if available, otherwise use CPU
-    torch_device = get_reconstruction_processing_unit(global_settings)
+    torch_device = get_processing_device(global_settings)
+    
+    if torch_device == torch.device('cpu'):  # warn the user that CPU reconstruction is slow
+        logger.warning(f"Reconstructing on CPU is slow. Check if cuda is available 'torch.cuda.is_available()'.")
 
     sensor_positions = sensor_positions.to(torch_device)
     time_series_sensor_data = time_series_sensor_data.to(torch_device)
@@ -401,24 +404,6 @@ def preparing_reconstruction_and_obtaining_reconstruction_settings(
 
     return (time_series_sensor_data, sensor_positions, speed_of_sound_in_m_per_s, spacing_in_mm,
             time_spacing_in_ms, torch_device)
-
-
-def get_reconstruction_processing_unit(global_settings: Settings) -> torch.device:
-    """
-    Get torch device (CPU/GPU) for reconstructing the image. Warns if CPU is used that the reconstruction will be slow.
-    :param global_settings: global SIMPA settings
-    :type global_settings: Settings
-    :return: torch device for reconstruction
-    """
-
-    device = get_processing_device(global_settings)
-    
-    if device == torch.device('cpu'):  # warn the user that CPU reconstruction is slow
-        logger = Logger()
-        logger.warning(f"Reconstructing on CPU is slow. Check if cuda is available 'torch.cuda.is_available()'.")
-
-    return device
-
 
 def compute_image_dimensions(detection_geometry: DetectionGeometryBase, spacing_in_mm: float,
                              speed_of_sound_in_m_per_s: float, logger: Logger) -> Tuple[int, int, int, int, int,

--- a/simpa/utils/processing_device.py
+++ b/simpa/utils/processing_device.py
@@ -8,7 +8,7 @@ from simpa.log import Logger
 from simpa.utils import Tags, Settings
 
 
-def get_processing_device(used_settings: Settings = None) -> torch.device:
+def get_processing_device(global_settings: Settings = None) -> torch.device:
     """
     Get device (CPU/GPU) for data processing. By default use GPU for fast computation, unless the user manually sets it to CPU. Of course, GPU is only used if available. The user receives a warning if GPU was specified but is not available, in this case processing is done on CPU as fall-back.
     :param global_settings: global settings defined by user
@@ -21,16 +21,16 @@ def get_processing_device(used_settings: Settings = None) -> torch.device:
     dev = "cuda"  # by default, the GPU is used
 
     # if the user has specified to use a CPU, do so
-    if used_settings is not None:
-        if Tags.GPU in used_settings:
-            if not used_settings[Tags.GPU]:
+    if global_settings is not None:
+        if Tags.GPU in global_settings:
+            if not global_settings[Tags.GPU]:
                 dev = "cpu"
 
     # if no GPU is available, use the CPU and inform the user
     if dev == "cuda" and not torch.cuda.is_available():
         dev = "cpu"
-        if used_settings is not None:
-            if Tags.GPU in used_settings:
+        if global_settings is not None:
+            if Tags.GPU in global_settings:
                 logger.warning('Cuda is not available! Check your torch/cuda version. Processing will be done on CPU instead.')
 
     logger.debug(f"Processing is done on {dev}")

--- a/simpa/utils/processing_device.py
+++ b/simpa/utils/processing_device.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2021 Division of Intelligent Medical Systems, DKFZ
+# SPDX-FileCopyrightText: 2021 Janek Groehl
+# SPDX-License-Identifier: MIT
+
+from doctest import ELLIPSIS_MARKER
+import torch
+from simpa.log import Logger
+from simpa.utils import Tags, Settings
+
+
+def get_processing_device(used_settings: Settings = None) -> torch.device:
+    """
+    Get device (CPU/GPU) for data processing. By default use GPU for fast computation, unless the user manually sets it to CPU. Of course, GPU is only used if available. The user receives a warning if GPU was specified but is not available, in this case processing is done on CPU as fall-back.
+    :param global_settings: global settings defined by user
+    :type global_settings: Settings
+    :return: torch device for processing
+    """
+
+    logger = Logger()
+
+    dev = "cuda"  # by default, the GPU is used
+
+    # if the user has specified to use a CPU, do so
+    if used_settings is not None:
+        if Tags.GPU in used_settings:
+            if not used_settings[Tags.GPU]:
+                dev = "cpu"
+
+    # if no GPU is available, use the CPU and inform the user
+    if dev == "cuda" and not torch.cuda.is_available():
+        dev = "cpu"
+        if used_settings is not None:
+            if Tags.GPU in used_settings:
+                logger.warning('Cuda is not available! Check your torch/cuda version. Processing will be done on CPU instead.')
+
+    logger.debug(f"Processing is done on {dev}")
+
+    return torch.device(dev)

--- a/simpa_tests/automatic_tests/test_processing_device.py
+++ b/simpa_tests/automatic_tests/test_processing_device.py
@@ -41,7 +41,7 @@ class TestProcessing(unittest.TestCase):
         assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
 
         # actual test case
-        device = get_processing_device(used_settings=None)
+        device = get_processing_device(global_settings=None)
         assert device == torch.device("cuda"), f"Processing device is not the assumed torch GPU device, but {device}"
 
         # mock pre-requisite for this test case that cuda is not available
@@ -49,7 +49,7 @@ class TestProcessing(unittest.TestCase):
         assert not torch.cuda.is_available(), "Check that CUDA is not avilable"
 
         # actual test case
-        device = get_processing_device(used_settings=None)
+        device = get_processing_device(global_settings=None)
         assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
 
         # restore torch.cuda
@@ -70,7 +70,7 @@ class TestProcessing(unittest.TestCase):
         assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
 
         # actual test case
-        device = get_processing_device(used_settings=self.settings_without_tag)
+        device = get_processing_device(global_settings=self.settings_without_tag)
         assert device == torch.device("cuda"), f"Processing device is not the assumed torch GPU device, but {device}"
 
         # mock pre-requisite for this test case that cuda is not available
@@ -78,7 +78,7 @@ class TestProcessing(unittest.TestCase):
         assert not torch.cuda.is_available(), "Check that CUDA is not avilable"
 
         # actual test case
-        device = get_processing_device(used_settings=self.settings_without_tag)
+        device = get_processing_device(global_settings=self.settings_without_tag)
         assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
 
         # restore torch.cuda
@@ -100,7 +100,7 @@ class TestProcessing(unittest.TestCase):
         assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
 
         # actual test case
-        device = get_processing_device(used_settings=self.settings_with_GPU)
+        device = get_processing_device(global_settings=self.settings_with_GPU)
         assert device == torch.device("cuda"), f"Processing device is not the assumed torch GPU device, but {device}"
 
         # mock pre-requisite for this test case that cuda is not available
@@ -109,7 +109,7 @@ class TestProcessing(unittest.TestCase):
 
         # actual test case
         with self.assertLogs("SIMPA Logger", level='WARN') as context_manager:
-            device = get_processing_device(used_settings=self.settings_with_GPU)
+            device = get_processing_device(global_settings=self.settings_with_GPU)
             
             assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
 
@@ -134,7 +134,7 @@ class TestProcessing(unittest.TestCase):
         assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
 
         # actual test case
-        device = get_processing_device(used_settings=self.settings_with_CPU)
+        device = get_processing_device(global_settings=self.settings_with_CPU)
         assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
 
         # mock pre-requisite for this test case that cuda is not available
@@ -142,7 +142,7 @@ class TestProcessing(unittest.TestCase):
         assert not torch.cuda.is_available(), "Check that CUDA is not avilable"
 
         # actual test case
-        device = get_processing_device(used_settings=self.settings_with_CPU)
+        device = get_processing_device(global_settings=self.settings_with_CPU)
         assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
 
         # restore torch.cuda

--- a/simpa_tests/automatic_tests/test_processing_device.py
+++ b/simpa_tests/automatic_tests/test_processing_device.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2021 Division of Intelligent Medical Systems, DKFZ
+# SPDX-FileCopyrightText: 2021 Janek Groehl
+# SPDX-License-Identifier: MIT
+
+from simpa.log.file_logger import Logger
+from simpa.utils.tags import Tags
+from simpa.utils.settings import Settings
+from simpa.utils.processing_device import get_processing_device
+import unittest
+from unittest.mock import Mock
+import torch
+
+
+class TestProcessing(unittest.TestCase):
+
+    def setUp(self):
+        print("setUp")
+
+        self.settings_without_tag = Settings()
+
+        self.settings_with_GPU = Settings({
+            Tags.GPU: True
+        })
+
+        self.settings_with_CPU = Settings({
+            Tags.GPU: False
+        })
+
+    def test_get_processing_device_with_no_settings(self):
+        '''
+        If cuda is available and no settings are given by the user, verify that a torch GPU device is returned.
+        '''
+
+        print("test get_processing_device with no settings")
+
+        # mock pre-requisite for this test case that cuda is available
+        temp_cuda = torch.cuda
+        mock = Mock()
+        mock.is_available.return_value = True
+        torch.cuda = mock
+        assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
+
+        # actual test case
+        device = get_processing_device(used_settings=None)
+        assert device == torch.device("cuda"), f"Processing device is not the assumed torch GPU device, but {device}"
+
+        # mock pre-requisite for this test case that cuda is not available
+        torch.cuda.is_available.return_value = False
+        assert not torch.cuda.is_available(), "Check that CUDA is not avilable"
+
+        # actual test case
+        device = get_processing_device(used_settings=None)
+        assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
+
+        # restore torch.cuda
+        torch.cuda = temp_cuda
+
+    def test_get_processing_device_with_settings_without_tag(self):
+        '''
+        If cuda is available and no Tag is specified in settings by user, verify that a torch GPU device is returned
+        '''
+
+        print("test get_processing_device with settings without tag")
+
+        # mock pre-requisite for this test case that cuda is available
+        temp_cuda = torch.cuda
+        mock = Mock()
+        mock.is_available.return_value = True
+        torch.cuda = mock
+        assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
+
+        # actual test case
+        device = get_processing_device(used_settings=self.settings_without_tag)
+        assert device == torch.device("cuda"), f"Processing device is not the assumed torch GPU device, but {device}"
+
+        # mock pre-requisite for this test case that cuda is not available
+        torch.cuda.is_available.return_value = False
+        assert not torch.cuda.is_available(), "Check that CUDA is not avilable"
+
+        # actual test case
+        device = get_processing_device(used_settings=self.settings_without_tag)
+        assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
+
+        # restore torch.cuda
+        torch.cuda = temp_cuda
+
+
+    def test_get_processing_device_with_settings_with_gpu(self):
+        '''
+        If cuda is available and GPU Tag is specified as True in settings by user, verify that a torch GPU device is returned
+        '''
+
+        print("test get_processing_device with settings with GPU tag")
+
+        # mock pre-requisite for this test case that cuda is available
+        temp_cuda = torch.cuda
+        mock = Mock()
+        mock.is_available.return_value = True
+        torch.cuda = mock
+        assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
+
+        # actual test case
+        device = get_processing_device(used_settings=self.settings_with_GPU)
+        assert device == torch.device("cuda"), f"Processing device is not the assumed torch GPU device, but {device}"
+
+        # mock pre-requisite for this test case that cuda is not available
+        torch.cuda.is_available.return_value = False
+        assert not torch.cuda.is_available(), "Check that CUDA is not avilable"
+
+        # actual test case
+        with self.assertLogs("SIMPA Logger", level='WARN') as context_manager:
+            device = get_processing_device(used_settings=self.settings_with_GPU)
+            
+            assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
+
+            # also check if warning is logged
+            assert context_manager.output == ['WARNING:SIMPA Logger:Cuda is not available! Check your torch/cuda version. Processing will be done on CPU instead.'], "Warning that CPU instead of GPU is used is not logged"
+        
+        # restore torch.cuda
+        torch.cuda = temp_cuda
+
+    def test_get_processing_device_with_settings_with_cpu(self):
+        '''
+        If cuda is available or not and GPU Tag is specified as False in settings by user, verify that a torch CPU device is returned
+        '''
+
+        print("test get_processing_device with settings with GPU tag set to False")
+
+        # mock pre-requisite for this test case that cuda is available
+        temp_cuda = torch.cuda
+        mock = Mock()
+        mock.is_available.return_value = True
+        torch.cuda = mock
+        assert torch.cuda.is_available(), "Check that CUDA is avilable, otherwise the CPU will always be used"
+
+        # actual test case
+        device = get_processing_device(used_settings=self.settings_with_CPU)
+        assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
+
+        # mock pre-requisite for this test case that cuda is not available
+        torch.cuda.is_available.return_value = False
+        assert not torch.cuda.is_available(), "Check that CUDA is not avilable"
+
+        # actual test case
+        device = get_processing_device(used_settings=self.settings_with_CPU)
+        assert device == torch.device("cpu"), f"Processing device is not the assumed torch CPU device, but {device}"
+
+        # restore torch.cuda
+        torch.cuda = temp_cuda
+        
+
+if __name__ == "__main__":
+    test = TestProcessing()
+    test.setUp()
+    test.test_get_processing_device_with_no_settings()
+    test.test_get_processing_device_with_settings_without_tag()
+    test.test_get_processing_device_with_settings_with_gpu()
+    test.test_get_processing_device_with_settings_with_cpu()


### PR DESCRIPTION
Fixes issue #152 by implementing a global utility function that determines whether a GPU or CPU is used for processing depending on the user choice and availability of a GPU. 

By default use GPU for fast computation, unless the user manually sets it to CPU. Of course, GPU is only used if available. The user receives a warning if GPU was specified but is not available, in this case processing is done on CPU as fall-back.

This function can then also be used for issue #166 