### PR TITLE
T187 bump jdata version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ docs/objects.inv
 simpa_tests/figures
 simpa_tests/figures/*
 
+path_config.env
+
 *.orig
 */*.orig
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,7 +34,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -196,7 +196,7 @@ pynrrd = "*"
 
 [[package]]
 name = "jdata"
-version = "0.4.4"
+version = "0.5.2"
 description = "Encoding and decoding Python data structrues using portable JData-annotated formats"
 category = "main"
 optional = false
@@ -240,7 +240,7 @@ mdurl = ">=0.1,<1.0"
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
-code_style = ["pre-commit (==2.6)"]
+code-style = ["pre-commit (==2.6)"]
 compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.3.6,<3.4.0)", "mistletoe (>=0.8.1,<0.9.0)", "mistune (>=2.0.2,<2.1.0)", "panflute (>=2.1.3,<2.2.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 plugins = ["mdit-py-plugins"]
@@ -287,7 +287,7 @@ python-versions = "~=3.6"
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-code_style = ["pre-commit (==2.6)"]
+code-style = ["pre-commit (==2.6)"]
 rtd = ["myst-parser (>=0.14.0,<0.15.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
 testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
 
@@ -317,7 +317,7 @@ sphinx = ">=4,<6"
 typing-extensions = "*"
 
 [package.extras]
-code_style = ["pre-commit (>=2.12,<3.0)"]
+code-style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
 testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx-pytest"]
@@ -487,7 +487,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "scikit-image"
@@ -914,8 +914,8 @@ ipasc-tool = [
     {file = "ipasc_tool-0.1.3-py3-none-any.whl", hash = "sha256:83b8849894af582f53d9cda835a507f40b478f99354a0bae8706fb882034da22"},
 ]
 jdata = [
-    {file = "jdata-0.4.4-py2.py3-none-any.whl", hash = "sha256:4792121d5bc6314a9231459d3f05d4a963e0e7f4dee614dd9ab41b7241654211"},
-    {file = "jdata-0.4.4.tar.gz", hash = "sha256:5a5554071015c14a2082eb7a4340049e8aac10a69238a95946668c1f0a0d0912"},
+    {file = "jdata-0.5.2-py2.py3-none-any.whl", hash = "sha256:925e5a55e3a3076ec286143e8e9ecbcbfe79673b870257fcbd78e38368b6d294"},
+    {file = "jdata-0.5.2.tar.gz", hash = "sha256:9772908ed14ff8346121c82dbdf561b7aba404939972a2abd03c2bd100f21448"},
 ]
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ python-dotenv = ">=0.19.2"   # Uses BSD-License (MIT compatible)
 ipasc-tool = ">=0.1.3"       # Uses BSD-License (MIT compatible)
 requests = ">=2.26.0"        # Uses Apache 2.0-License (MIT compatible)
 wget = ">=3.2"               # Is Public Domain (MIT compatible)
-jdata = ">=0.3.7"            # Uses Apache 2.0-License (MIT compatible)
+jdata = ">=0.5.2"            # Uses Apache 2.0-License (MIT compatible)
 
 [tool.poetry.group.docs.dependencies]
 sphinx-rtd-theme = "^1.0.0"


### PR DESCRIPTION
Bumped `jdata` version to fix read only arrays when loading diffuse reflectance results. Also added `path_config.env` to `.gitignore`.