### PR TITLE
Quick fix: Upper bound for numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 matplotlib = ">=3.5.0"       # Uses PSF-License (MIT compatible)
-numpy = ">=1.21.4"           # Uses BSD-License (MIT compatible)
+numpy = ">=1.21.4, <1.24.0"           # Uses BSD-License (MIT compatible)
 scipy = ">=1.7.2"            # Uses BSD-like-License (MIT compatible)
 pynrrd = ">=0.4.2"           # Uses MIT-License (MIT compatible)
 scikit-image = ">=0.18.3"    # Uses BSD-License (MIT compatible)


### PR DESCRIPTION
A quick fix for the numpy issue #191 
In the long run we might want to get rid of `np.bool` in our code base so that we can use the latest numpy version again.