### PR TITLE
Injects git commit hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+GIT_COMMIT_HASH
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/docs/inject_git_commit_hash.py
+++ b/docs/inject_git_commit_hash.py
@@ -1,11 +1,13 @@
 import subprocess
 
+
 # retrieves the latest git commit hash and saves it into a file
 def build():
     hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
     f = open("GIT_COMMIT_HASH", "w")
     f.write(hash)
     f.close()
+
 
 if __name__ == '__main__':
     build()

--- a/inject_git_commit_hash.py
+++ b/inject_git_commit_hash.py
@@ -1,0 +1,11 @@
+import subprocess
+
+# retrieves the latest git commit hash and saves it into a file
+def build():
+    hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+    f = open("GIT_COMMIT_HASH", "w")
+    f.write(hash)
+    f.close()
+
+if __name__ == '__main__':
+    build()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simpa"
-version = "0.8.11"
+version = "0.8.13"
 description = "Simulation and Image Processing for Photonics and Acoustics"
 authors = [
     "Division of Intelligent Medical Systems (IMSY), DKFZ <k.dreher@dkfz-heidelberg.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Sphinx = "^5.1.1"
 myst-parser = "^0.18.0"
 
 [tool.poetry.build] 
-script = "inject_git_commit_hash.py" 
+script = "docs/inject_git_commit_hash.py"
 generate-setup-file = false 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ sphinx-rtd-theme = "^1.0.0"
 Sphinx = "^5.1.1"
 myst-parser = "^0.18.0"
 
+[tool.poetry.build] 
+script = "inject_git_commit_hash.py" 
+generate-setup-file = false 
+
 [build-system]
 requires = [
     "poetry >= 0.12"

--- a/simpa/__init__.py
+++ b/simpa/__init__.py
@@ -55,3 +55,7 @@ from .visualisation.matplotlib_device_visualisation import visualise_device
 
 from .utils.quality_assurance.data_sanity_testing import assert_equal_shapes
 from .utils.quality_assurance.data_sanity_testing import assert_array_well_defined
+
+# file will be written during build process
+f = open('GIT_COMMIT_HASH','r')
+__git_commit_hash__ = f.readline()

--- a/simpa/__init__.py
+++ b/simpa/__init__.py
@@ -57,5 +57,5 @@ from .utils.quality_assurance.data_sanity_testing import assert_equal_shapes
 from .utils.quality_assurance.data_sanity_testing import assert_array_well_defined
 
 # file will be written during build process
-f = open('GIT_COMMIT_HASH','r')
+f = open('GIT_COMMIT_HASH', 'r')
 __git_commit_hash__ = f.readline()


### PR DESCRIPTION
During the build process simpa now injects the latest git commit hash, so that it is available in the package by calling `simpa.__git_commit_hash__`. This might be very useful for reproducibility purposes. Fixes issue #173. 

So far I've only tested it when installing simpa locally with `pip install .` It also needs to be tested if it works when publishing the package to PyPI and installing it via `pip install simpa`. 