### PR TITLE
use process unique file naming for kwave files

### DIFF
--- a/simpa/core/simulation_modules/acoustic_forward_module/simulate_2D.m
+++ b/simpa/core/simulation_modules/acoustic_forward_module/simulate_2D.m
@@ -147,11 +147,19 @@ else
     datacast = 'single';
 end
 
+
+basename = strsplit(optical_path, '/');
+basename = strsplit(basename{end}, '.');
+basename = basename{1};
+date_str = datestr(now, 'HH-MM-SS-FFF');
+pid = feature('GetPid');
+tmp_path_name = ['kwave__' basename '__' date_str '__' num2str(pid)];
+
 input_args = {'DataCast', datacast, 'PMLInside', settings.pml_inside, ...
                'PMLAlpha', settings.pml_alpha, 'PMLSize', 'auto', ...
                'PlotPML', settings.plot_pml, 'RecordMovie', settings.record_movie, ...
                'MovieName', settings.movie_name, 'PlotScale', [-1, 1], 'LogScale', settings.acoustic_log_scale, ...
-               'Smooth', p0_smoothing};
+               'Smooth', p0_smoothing, 'DataName', tmp_path_name};
 
 if settings.gpu == true
     time_series_data = kspaceFirstOrder2DG(kgrid, medium, source, sensor, input_args{:});


### PR DESCRIPTION
Fixes #215 

We provide a name for the temporary kwave files. Previously, a default naming convention was used internally (only based on the current time) which could cause problems when running multiple instances.