### PR TITLE
Fix relative path issue in reconstruction_module_time_reversal_adapter.py matlab command

### DIFF
--- a/simpa/core/simulation_modules/acoustic_forward_module/acoustic_forward_module_k_wave_adapter.py
+++ b/simpa/core/simulation_modules/acoustic_forward_module/acoustic_forward_module_k_wave_adapter.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 import gc
-import inspect
 import os
 import subprocess
 
@@ -17,6 +16,7 @@ from simpa.core.simulation_modules.acoustic_forward_module import \
     AcousticForwardModelBaseAdapter
 from simpa.io_handling.io_hdf5 import load_data_field, save_hdf5
 from simpa.utils import Tags
+from simpa.utils.matlab import generate_matlab_cmd
 from simpa.utils.calculate import rotation_matrix_between_vectors
 from simpa.utils.dict_path_manager import generate_dict_path
 from simpa.utils.path_manager import PathManager
@@ -240,17 +240,9 @@ class KWaveAdapter(AcousticForwardModelBaseAdapter):
             self.logger.info("Simulating 2D....")
             simulation_script_path = "simulate_2D"
 
-        base_script_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+        matlab_binary_path = self.component_settings[Tags.ACOUSTIC_MODEL_BINARY_PATH]
+        cmd = generate_matlab_cmd(matlab_binary_path, simulation_script_path, optical_path)
 
-        cmd = list()
-        cmd.append(self.component_settings[Tags.ACOUSTIC_MODEL_BINARY_PATH])
-        cmd.append("-nodisplay")
-        cmd.append("-nosplash")
-        cmd.append("-automation")
-        cmd.append("-wait")
-        cmd.append("-r")
-        cmd.append("addpath('" + base_script_path + "');" +
-                   simulation_script_path + "('" + optical_path + "');exit;")
         cur_dir = os.getcwd()
         self.logger.info(cmd)
         subprocess.run(cmd)

--- a/simpa/core/simulation_modules/reconstruction_module/reconstruction_module_time_reversal_adapter.py
+++ b/simpa/core/simulation_modules/reconstruction_module/reconstruction_module_time_reversal_adapter.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from simpa.utils import Tags
+from simpa.utils.matlab import generate_matlab_cmd
 from simpa.utils.settings import Settings
 from simpa.core.simulation_modules.reconstruction_module import ReconstructionAdapterBase
 from simpa.core.device_digital_twins import LinearArrayDetectionGeometry
@@ -10,7 +11,6 @@ import numpy as np
 import scipy.io as sio
 import subprocess
 import os
-import inspect
 
 
 class TimeReversalAdapter(ReconstructionAdapterBase):
@@ -168,17 +168,8 @@ class TimeReversalAdapter(ReconstructionAdapterBase):
             time_reversal_script = "time_reversal_2D"
             axes = (0, 1)
 
-        base_script_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-
-        cmd = list()
-        cmd.append(self.component_settings[Tags.ACOUSTIC_MODEL_BINARY_PATH])
-        cmd.append("-nodisplay")
-        cmd.append("-nosplash")
-        cmd.append("-automation")
-        cmd.append("-wait")
-        cmd.append("-r")
-        cmd.append("addpath('" + base_script_path + "');" +
-                   time_reversal_script + "('" + acoustic_path + "');exit;")
+        matlab_binary_path = self.component_settings[Tags.ACOUSTIC_MODEL_BINARY_PATH]
+        cmd = generate_matlab_cmd(matlab_binary_path, time_reversal_script, acoustic_path)
 
         cur_dir = os.getcwd()
         os.chdir(self.global_settings[Tags.SIMULATION_PATH])

--- a/simpa/utils/matlab.py
+++ b/simpa/utils/matlab.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2021 Division of Intelligent Medical Systems, DKFZ
+# SPDX-FileCopyrightText: 2021 Janek Groehl
+# SPDX-License-Identifier: MIT
+
+import inspect
+import os
+from typing import List
+
+
+def generate_matlab_cmd(matlab_binary_path: str, simulation_script_path: str, data_path: str) -> List[str]:
+    # get path of calling script to add to matlab path
+    base_script_path = os.path.dirname(os.path.abspath(inspect.stack()[1].filename))
+    # ensure data path is an absolute path
+    data_path = os.path.abspath(data_path)
+
+    cmd = list()
+    cmd.append(matlab_binary_path)
+    cmd.append("-nodisplay")
+    cmd.append("-nosplash")
+    cmd.append("-automation")
+    cmd.append("-wait")
+    cmd.append("-r")
+    cmd.append(f"addpath('{base_script_path}');{simulation_script_path}('{data_path}');exit;")
+    return cmd


### PR DESCRIPTION
- ensure absolute path is used for data path argument to matlab script
- refactor duplicated code into `utils.matlab.generate_matlab_cmd`

 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [ ] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
 **List any specific code review questions**
  
 **List any special testing requirements**
 
 **Additional context (e.g. papers, documentation, blog posts, ...)**
  
 **Provide issue / feature request fixed by this PR**
 
 Fixes #233
