### PR TITLE
speed up `assert_array_well_defined()`

### DIFF
--- a/simpa/utils/quality_assurance/data_sanity_testing.py
+++ b/simpa/utils/quality_assurance/data_sanity_testing.py
@@ -42,24 +42,18 @@ def assert_array_well_defined(array: np.ndarray, assume_non_negativity: bool = F
     :raises AssertionError: if there are any unexpected values in the given array.
     """
 
-    if array_name is None:
-        array_name = "'Not specified'"
-    caller = inspect.stack()[1]
-    stack_string = f" \n\tArray Name: {array_name} \n\tCaller: {caller.filename}" \
-                   f" \n\tline: {caller.lineno} \n\tcode: {caller.code_context}"
-
-    if np.isinf(array).any() or np.isneginf(array).any():
-        raise AssertionError("The given array contained values that were inf or -inf."
-                             f" Info: {stack_string}.")
-
-    if np.isnan(array).any():
-        raise AssertionError("The given array contained values that were nan."
-                             f" Info: {stack_string}.")
-
+    error_message = None
+    if not np.isfinite(array).all():
+        error_message = "nan, inf or -inf"
     if assume_positivity and (array <= 0).any():
-        raise AssertionError("The given array contained values that were not positive."
-                             f" Info: {stack_string}.")
-
+        error_message = "not positive"
     if assume_non_negativity and (array < 0).any():
-        raise AssertionError("The given array contained values that were negative."
+        error_message = "negative"
+    if error_message:
+        if array_name is None:
+            array_name = "'Not specified'"
+        caller = inspect.stack()[1]
+        stack_string = f" \n\tArray Name: {array_name} \n\tCaller: {caller.filename}" \
+                       f" \n\tline: {caller.lineno} \n\tcode: {caller.code_context}"
+        raise AssertionError(f"The given array contained values that were {error_message}."
                              f" Info: {stack_string}.")


### PR DESCRIPTION
- use `isfinite()` instead of `isinf()`, `isnan()`, `isneginf()`, to iterate array once instead of three times
- only construct stack string if needed
- runtime in script: 1.06s -> 0.19s

 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [ ] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
 **List any specific code review questions**
  
 **List any special testing requirements**
 
 **Additional context (e.g. papers, documentation, blog posts, ...)**
  
 **Provide issue / feature request fixed by this PR**
 
 Fixes #<ISSUE NUMBER>
