### PR TITLE
T239 wavelength independent volume creation

### DIFF
--- a/simpa/core/processing_components/monospectral/field_of_view_cropping.py
+++ b/simpa/core/processing_components/monospectral/field_of_view_cropping.py
@@ -60,6 +60,7 @@ class FieldOfViewCropping(ProcessingComponent):
         wavelength = self.global_settings[Tags.WAVELENGTH]
 
         for data_field in data_fields:
+            # Crop wavelength-independent properties only in the last wavelength run
             if (data_field in TissueProperties.wavelength_independent_properties
                     and wavelength != self.global_settings[Tags.WAVELENGTHS][-1]):
                 continue

--- a/simpa/core/processing_components/monospectral/field_of_view_cropping.py
+++ b/simpa/core/processing_components/monospectral/field_of_view_cropping.py
@@ -57,11 +57,13 @@ class FieldOfViewCropping(ProcessingComponent):
 
         self.logger.debug(f"field of view to crop: {field_of_view_voxels}")
 
-        for data_field in data_fields:
-            self.logger.debug(f"Cropping data field {data_field}...")
+        wavelength = self.global_settings[Tags.WAVELENGTH]
 
-            # load
-            wavelength = self.global_settings[Tags.WAVELENGTH]
+        for data_field in data_fields:
+            if (data_field in TissueProperties.wavelength_independent_properties
+                    and wavelength != self.global_settings[Tags.WAVELENGTHS][-1]):
+                continue
+            self.logger.debug(f"Cropping data field {data_field}...")
             data_array = load_data_field(self.global_settings[Tags.SIMPA_OUTPUT_PATH], data_field, wavelength)
             self.logger.debug(f"data array shape before cropping: {np.shape(data_array)}")
             self.logger.debug(f"data array shape len: {len(np.shape(data_array))}")

--- a/simpa/core/simulation_modules/acoustic_forward_module/acoustic_forward_module_k_wave_adapter.py
+++ b/simpa/core/simulation_modules/acoustic_forward_module/acoustic_forward_module_k_wave_adapter.py
@@ -84,7 +84,8 @@ class KWaveAdapter(AcousticForwardModelBaseAdapter):
 
         data_dict = {}
         file_path = self.global_settings[Tags.SIMPA_OUTPUT_PATH]
-        data_dict[Tags.DATA_FIELD_INITIAL_PRESSURE] = load_data_field(file_path, Tags.DATA_FIELD_INITIAL_PRESSURE)
+        data_dict[Tags.DATA_FIELD_INITIAL_PRESSURE] = load_data_field(file_path, Tags.DATA_FIELD_INITIAL_PRESSURE,
+                                                                      wavelength=wavelength)
         data_dict[Tags.DATA_FIELD_SPEED_OF_SOUND] = load_data_field(file_path, Tags.DATA_FIELD_SPEED_OF_SOUND)
         data_dict[Tags.DATA_FIELD_DENSITY] = load_data_field(file_path, Tags.DATA_FIELD_DENSITY)
         data_dict[Tags.DATA_FIELD_ALPHA_COEFF] = load_data_field(file_path, Tags.DATA_FIELD_ALPHA_COEFF)
@@ -116,7 +117,7 @@ class KWaveAdapter(AcousticForwardModelBaseAdapter):
         data_dict[Tags.DATA_FIELD_ALPHA_COEFF] = np.rot90(data_dict[Tags.DATA_FIELD_ALPHA_COEFF][image_slice],
                                                           3, axes=axes)
         data_dict[Tags.DATA_FIELD_INITIAL_PRESSURE] = np.rot90(data_dict[Tags.DATA_FIELD_INITIAL_PRESSURE]
-                                                               [wavelength][image_slice], 3, axes=axes)
+                                                               [image_slice], 3, axes=axes)
 
         time_series_data, global_settings = self.k_wave_acoustic_forward_model(
             detection_geometry,

--- a/simpa/core/simulation_modules/acoustic_forward_module/acoustic_forward_module_k_wave_adapter.py
+++ b/simpa/core/simulation_modules/acoustic_forward_module/acoustic_forward_module_k_wave_adapter.py
@@ -76,8 +76,9 @@ class KWaveAdapter(AcousticForwardModelBaseAdapter):
 
         """
 
+        wavelength = self.global_settings[Tags.WAVELENGTH]
         optical_path = generate_dict_path(Tags.OPTICAL_MODEL_OUTPUT_NAME,
-                                          wavelength=self.global_settings[Tags.WAVELENGTH])
+                                          wavelength=wavelength)
 
         self.logger.debug(f"OPTICAL_PATH: {str(optical_path)}")
 
@@ -108,7 +109,6 @@ class KWaveAdapter(AcousticForwardModelBaseAdapter):
             axes = (0, 2)
             image_slice = np.s_[:]
 
-        wavelength = str(self.global_settings[Tags.WAVELENGTH])
         data_dict[Tags.DATA_FIELD_SPEED_OF_SOUND] = np.rot90(data_dict[Tags.DATA_FIELD_SPEED_OF_SOUND][image_slice],
                                                              3, axes=axes)
         data_dict[Tags.DATA_FIELD_DENSITY] = np.rot90(data_dict[Tags.DATA_FIELD_DENSITY][image_slice],

--- a/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
+++ b/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2021 Janek Groehl
 # SPDX-License-Identifier: MIT
 
-from simpa.core.simulation_modules.volume_creation_module import VolumeCreatorModuleBase
+from simpa.core.simulation_modules.volume_creation_module import VolumeCreatorModuleBase, TissueProperties
 from simpa.utils.libraries.structure_library import Structures
 from simpa.utils import Tags
 import numpy as np
@@ -89,6 +89,9 @@ class ModelBasedVolumeCreationAdapter(VolumeCreatorModuleBase):
                                                                       fraction_to_be_filled], axis=0)
             for key in volumes.keys():
                 if structure_properties[key] is None:
+                    continue
+                if (key in TissueProperties.wavelength_independent_properties
+                        and wavelength != self.global_settings[Tags.WAVELENGTHS][0]):
                     continue
                 if key == Tags.DATA_FIELD_SEGMENTATION:
                     added_fraction_greater_than_any_added_fraction = added_volume_fraction > max_added_fractions

--- a/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
+++ b/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
@@ -90,6 +90,7 @@ class ModelBasedVolumeCreationAdapter(VolumeCreatorModuleBase):
             for key in volumes.keys():
                 if structure_properties[key] is None:
                     continue
+                # Create wavelength-independent properties only in the first wavelength run
                 if (key in TissueProperties.wavelength_independent_properties
                         and wavelength != self.global_settings[Tags.WAVELENGTHS][0]):
                     continue

--- a/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
+++ b/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2021 Janek Groehl
 # SPDX-License-Identifier: MIT
 
-from simpa.core.simulation_modules.volume_creation_module import VolumeCreatorModuleBase, TissueProperties
+from simpa.core.simulation_modules.volume_creation_module import VolumeCreatorModuleBase
 from simpa.utils.libraries.structure_library import Structures
 from simpa.utils import Tags
 import numpy as np
@@ -89,10 +89,6 @@ class ModelBasedVolumeCreationAdapter(VolumeCreatorModuleBase):
                                                                       fraction_to_be_filled], axis=0)
             for key in volumes.keys():
                 if structure_properties[key] is None:
-                    continue
-                # Create wavelength-independent properties only in the first wavelength run
-                if (key in TissueProperties.wavelength_independent_properties
-                        and wavelength != self.global_settings[Tags.WAVELENGTHS][0]):
                     continue
                 if key == Tags.DATA_FIELD_SEGMENTATION:
                     added_fraction_greater_than_any_added_fraction = added_volume_fraction > max_added_fractions

--- a/simpa/utils/tissue_properties.py
+++ b/simpa/utils/tissue_properties.py
@@ -7,15 +7,22 @@ from simpa.utils import Tags
 
 class TissueProperties(dict):
 
-    property_tags = [Tags.DATA_FIELD_ABSORPTION_PER_CM,
-                     Tags.DATA_FIELD_SCATTERING_PER_CM,
-                     Tags.DATA_FIELD_ANISOTROPY,
-                     Tags.DATA_FIELD_GRUNEISEN_PARAMETER,
-                     Tags.DATA_FIELD_SEGMENTATION,
-                     Tags.DATA_FIELD_OXYGENATION,
-                     Tags.DATA_FIELD_DENSITY,
-                     Tags.DATA_FIELD_SPEED_OF_SOUND,
-                     Tags.DATA_FIELD_ALPHA_COEFF]
+    wavelength_dependent_properties = [
+        Tags.DATA_FIELD_ABSORPTION_PER_CM,
+        Tags.DATA_FIELD_SCATTERING_PER_CM,
+        Tags.DATA_FIELD_ANISOTROPY
+    ]
+
+    wavelength_independent_properties = [
+        Tags.DATA_FIELD_GRUNEISEN_PARAMETER,
+        Tags.DATA_FIELD_SEGMENTATION,
+        Tags.DATA_FIELD_OXYGENATION,
+        Tags.DATA_FIELD_DENSITY,
+        Tags.DATA_FIELD_SPEED_OF_SOUND,
+        Tags.DATA_FIELD_ALPHA_COEFF
+    ]
+
+    property_tags = wavelength_dependent_properties + wavelength_independent_properties
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
- Create wavelength-independent properties only in the first wavelength run
- Crop wavelength-independent properties only in the last wavelength run
- Split Tissue properties in wavelength-dependent and wavelength-independent ones
- Speed up of `optical_and_acoustic_simulation.py` with spacing 0.1 and 5 wavelengths 122s :arrow_right:  110s

 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [x] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
 **Provide issue / feature request fixed by this PR**
 
 Fixes #239
