### PR TITLE
Create simulation volumes on the GPU

### DIFF
--- a/simpa/core/simulation_modules/reconstruction_module/reconstruction_module_delay_and_sum_adapter.py
+++ b/simpa/core/simulation_modules/reconstruction_module/reconstruction_module_delay_and_sum_adapter.py
@@ -6,7 +6,7 @@ from simpa.utils import Tags
 from simpa.core.simulation_modules.reconstruction_module import ReconstructionAdapterBase
 import numpy as np
 import torch
-from simpa.core.simulation_modules.reconstruction_module.reconstruction_utils import compute_delay_and_sum_values,\
+from simpa.core.simulation_modules.reconstruction_module.reconstruction_utils import compute_delay_and_sum_values, \
     compute_image_dimensions, preparing_reconstruction_and_obtaining_reconstruction_settings
 from simpa.core.device_digital_twins import DetectionGeometryBase
 from simpa.core.simulation_modules.reconstruction_module import create_reconstruction_settings

--- a/simpa/core/simulation_modules/volume_creation_module/__init__.py
+++ b/simpa/core/simulation_modules/volume_creation_module/__init__.py
@@ -7,10 +7,12 @@ from simpa.utils.settings import Settings
 from simpa.utils import Tags
 from simpa.utils.tissue_properties import TissueProperties
 import numpy as np
+import torch
 from simpa.core import SimulationModule
 from simpa.utils.dict_path_manager import generate_dict_path
 from simpa.io_handling import save_data_field
 from simpa.utils.quality_assurance.data_sanity_testing import assert_equal_shapes, assert_array_well_defined
+from simpa.utils.processing_device import get_processing_device
 
 
 class VolumeCreatorModuleBase(SimulationModule):
@@ -22,6 +24,7 @@ class VolumeCreatorModuleBase(SimulationModule):
     def __init__(self, global_settings: Settings):
         super(VolumeCreatorModuleBase, self).__init__(global_settings=global_settings)
         self.component_settings = global_settings.get_volume_creation_settings()
+        self.torch_device = get_processing_device(self.global_settings)
 
     def create_empty_volumes(self):
         volumes = dict()
@@ -38,7 +41,7 @@ class VolumeCreatorModuleBase(SimulationModule):
             # Create wavelength-independent properties only in the first wavelength run
             if key in TissueProperties.wavelength_independent_properties and wavelength != first_wavelength:
                 continue
-            volumes[key] = np.zeros(sizes)
+            volumes[key] = torch.zeros(sizes, dtype=torch.float, device=self.torch_device)
 
         return volumes, volume_x_dim, volume_y_dim, volume_z_dim
 
@@ -57,6 +60,8 @@ class VolumeCreatorModuleBase(SimulationModule):
         self.logger.info("VOLUME CREATION")
 
         volumes = self.create_simulation_volume()
+        # explicitly empty cache to free reserved GPU memory after volume creation
+        torch.cuda.empty_cache()
 
         if not (Tags.IGNORE_QA_ASSERTIONS in self.global_settings and Tags.IGNORE_QA_ASSERTIONS):
             assert_equal_shapes(list(volumes.values()))

--- a/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
+++ b/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from simpa.core.simulation_modules.volume_creation_module import VolumeCreatorModuleBase
-from simpa.utils.libraries.structure_library import Structures
+from simpa.utils.libraries.structure_library import priority_sorted_structures
 from simpa.utils import Tags
 import numpy as np
 from simpa.utils import create_deformation_settings
@@ -60,19 +60,18 @@ class ModelBasedVolumeCreationAdapter(VolumeCreatorModuleBase):
                     cosine_scaling_factor=1)
 
         volumes, x_dim_px, y_dim_px, z_dim_px = self.create_empty_volumes()
-        global_volume_fractions = np.zeros((x_dim_px, y_dim_px, z_dim_px))
-        max_added_fractions = np.zeros((x_dim_px, y_dim_px, z_dim_px))
+        global_volume_fractions = torch.zeros((x_dim_px, y_dim_px, z_dim_px),
+                                              dtype=torch.float, device=self.torch_device)
+        max_added_fractions = torch.zeros((x_dim_px, y_dim_px, z_dim_px), dtype=torch.float, device=self.torch_device)
         wavelength = self.global_settings[Tags.WAVELENGTH]
 
-        structure_list = Structures(self.global_settings, self.component_settings)
-        priority_sorted_structures = structure_list.sorted_structures
-
-        for structure in priority_sorted_structures:
+        for structure in priority_sorted_structures(self.global_settings, self.component_settings):
             self.logger.debug(type(structure))
 
             structure_properties = structure.properties_for_wavelength(wavelength)
 
-            structure_volume_fractions = structure.geometrical_volume
+            structure_volume_fractions = torch.as_tensor(
+                structure.geometrical_volume, dtype=torch.float, device=self.torch_device)
             structure_indexes_mask = structure_volume_fractions > 0
             global_volume_fractions_mask = global_volume_fractions < 1
             mask = structure_indexes_mask & global_volume_fractions_mask
@@ -82,11 +81,11 @@ class ModelBasedVolumeCreationAdapter(VolumeCreatorModuleBase):
                 added_volume_fraction <= 1 & mask]
 
             selector_more_than_1 = added_volume_fraction > 1
-            if selector_more_than_1.any():
+            if torch.any(selector_more_than_1):
                 remaining_volume_fraction_to_fill = 1 - global_volume_fractions[selector_more_than_1]
                 fraction_to_be_filled = structure_volume_fractions[selector_more_than_1]
-                added_volume_fraction[selector_more_than_1] = np.min([remaining_volume_fraction_to_fill,
-                                                                      fraction_to_be_filled], axis=0)
+                added_volume_fraction[selector_more_than_1] = torch.min(torch.stack((remaining_volume_fraction_to_fill,
+                                                                                     fraction_to_be_filled)), 0).values
             for key in volumes.keys():
                 if structure_properties[key] is None:
                     continue
@@ -100,7 +99,8 @@ class ModelBasedVolumeCreationAdapter(VolumeCreatorModuleBase):
 
             global_volume_fractions[mask] += added_volume_fraction[mask]
 
-        # explicitly empty cache to free reserved GPU memory after volume creation
-        torch.cuda.empty_cache()
+        # convert volumes back to CPU
+        for key in volumes.keys():
+            volumes[key] = volumes[key].cpu().numpy()
 
         return volumes

--- a/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
+++ b/simpa/core/simulation_modules/volume_creation_module/volume_creation_module_model_based_adapter.py
@@ -101,6 +101,6 @@ class ModelBasedVolumeCreationAdapter(VolumeCreatorModuleBase):
 
         # convert volumes back to CPU
         for key in volumes.keys():
-            volumes[key] = volumes[key].cpu().numpy()
+            volumes[key] = volumes[key].cpu().numpy().astype(np.float64, copy=False)
 
         return volumes

--- a/simpa/utils/libraries/structure_library/BackgroundStructure.py
+++ b/simpa/utils/libraries/structure_library/BackgroundStructure.py
@@ -24,7 +24,7 @@ class Background(GeometricalStructure):
     def get_enclosed_indices(self):
         array = np.ones((self.volume_dimensions_voxels[0],
                          self.volume_dimensions_voxels[1],
-                         self.volume_dimensions_voxels[2]))
+                         self.volume_dimensions_voxels[2]), dtype=np.float32)
         return array == 1, 1
 
     def get_params_from_settings(self, single_structure_settings):

--- a/simpa/utils/libraries/structure_library/CircularTubularStructure.py
+++ b/simpa/utils/libraries/structure_library/CircularTubularStructure.py
@@ -48,28 +48,26 @@ class CircularTubularStructure(GeometricalStructure):
 
     def get_enclosed_indices(self):
         start_mm, end_mm, radius_mm, partial_volume = self.params
-        start_mm = torch.tensor(start_mm, dtype=torch.float).to(self.torch_device)
-        end_mm = torch.tensor(end_mm, dtype=torch.float).to(self.torch_device)
-        radius_mm = torch.tensor(radius_mm, dtype=torch.float).to(self.torch_device)
+        start_mm = torch.tensor(start_mm, dtype=torch.float, device=self.torch_device)
+        end_mm = torch.tensor(end_mm, dtype=torch.float, device=self.torch_device)
+        radius_mm = torch.tensor(radius_mm, dtype=torch.float, device=self.torch_device)
         start_voxels = start_mm / self.voxel_spacing
         end_voxels = end_mm / self.voxel_spacing
         radius_voxels = radius_mm / self.voxel_spacing
 
-        x, y, z = torch.meshgrid(torch.arange(self.volume_dimensions_voxels[0]).to(self.torch_device),
-                                 torch.arange(self.volume_dimensions_voxels[1]).to(self.torch_device),
-                                 torch.arange(self.volume_dimensions_voxels[2]).to(self.torch_device),
-                                 indexing='ij')
-
-        x = x + 0.5
-        y = y + 0.5
-        z = z + 0.5
+        target_vector = torch.stack(torch.meshgrid(torch.arange(start=0.5, end=self.volume_dimensions_voxels[0], dtype=torch.float, device=self.torch_device),
+                                                   torch.arange(
+                                                       start=0.5, end=self.volume_dimensions_voxels[1], dtype=torch.float, device=self.torch_device),
+                                                   torch.arange(
+                                                       start=0.5, end=self.volume_dimensions_voxels[2], dtype=torch.float, device=self.torch_device),
+                                                   indexing='ij'), dim=-1)
+        target_vector -= start_voxels
 
         if partial_volume:
             radius_margin = 0.5
         else:
             radius_margin = 0.7071
 
-        target_vector = torch.subtract(torch.stack([x, y, z], axis=-1), start_voxels)
         if self.do_deformation:
             # the deformation functional needs mm as inputs and returns the result in reverse indexing order...
             deformation_values_mm = self.deformation_functional_mm(torch.arange(self.volume_dimensions_voxels[0]) *
@@ -78,16 +76,20 @@ class CircularTubularStructure(GeometricalStructure):
                                                                    self.voxel_spacing).T
             deformation_values_mm = deformation_values_mm.reshape(self.volume_dimensions_voxels[0],
                                                                   self.volume_dimensions_voxels[1], 1, 1)
-            deformation_values_mm = torch.tile(torch.from_numpy(deformation_values_mm).to(
-                self.torch_device), (1, 1, self.volume_dimensions_voxels[2], 3))
-            target_vector = (target_vector + (deformation_values_mm / self.voxel_spacing)).float()
+            deformation_values_mm = torch.tile(torch.as_tensor(
+                deformation_values_mm, dtype=torch.float, device=self.torch_device), (1, 1, self.volume_dimensions_voxels[2], 3))
+            deformation_values_mm /= self.voxel_spacing
+            target_vector += deformation_values_mm
+            del deformation_values_mm
         cylinder_vector = torch.subtract(end_voxels, start_voxels)
 
         target_radius = torch.linalg.norm(target_vector, axis=-1) * torch.sin(
             torch.arccos((torch.matmul(target_vector, cylinder_vector)) /
                          (torch.linalg.norm(target_vector, axis=-1) * torch.linalg.norm(cylinder_vector))))
+        del target_vector
 
-        volume_fractions = torch.zeros(tuple(self.volume_dimensions_voxels), dtype=torch.float).to(self.torch_device)
+        volume_fractions = torch.zeros(tuple(self.volume_dimensions_voxels),
+                                       dtype=torch.float, device=self.torch_device)
 
         filled_mask = target_radius <= radius_voxels - 1 + radius_margin
         border_mask = (target_radius > radius_voxels - 1 + radius_margin) & \

--- a/simpa/utils/libraries/structure_library/RectangularCuboidStructure.py
+++ b/simpa/utils/libraries/structure_library/RectangularCuboidStructure.py
@@ -78,8 +78,6 @@ class RectangularCuboidStructure(GeometricalStructure):
 
         inverse_matrix = torch.linalg.inv(matrix)
 
-        print(target_vector.shape)
-        print(inverse_matrix.shape)
         result = torch.matmul(target_vector, inverse_matrix)
         del target_vector
 

--- a/simpa/utils/libraries/structure_library/RectangularCuboidStructure.py
+++ b/simpa/utils/libraries/structure_library/RectangularCuboidStructure.py
@@ -52,40 +52,49 @@ class RectangularCuboidStructure(GeometricalStructure):
 
     def get_enclosed_indices(self):
         start_mm, x_edge_mm, y_edge_mm, z_edge_mm, partial_volume = self.params
-        start_mm = torch.tensor(start_mm, dtype=torch.float).to(self.torch_device)
-        x_edge_mm = torch.tensor(x_edge_mm, dtype=torch.float).to(self.torch_device)
-        y_edge_mm = torch.tensor(y_edge_mm, dtype=torch.float).to(self.torch_device)
-        z_edge_mm = torch.tensor(z_edge_mm, dtype=torch.float).to(self.torch_device)
+        start_mm = torch.tensor(start_mm, dtype=torch.float, device=self.torch_device)
+        x_edge_mm = torch.tensor(x_edge_mm, dtype=torch.float, device=self.torch_device)
+        y_edge_mm = torch.tensor(y_edge_mm, dtype=torch.float, device=self.torch_device)
+        z_edge_mm = torch.tensor(z_edge_mm, dtype=torch.float, device=self.torch_device)
 
         start_voxels = start_mm / self.voxel_spacing
-        x_edge_voxels = torch.tensor([x_edge_mm / self.voxel_spacing, 0, 0]).to(self.torch_device)
-        y_edge_voxels = torch.tensor([0, y_edge_mm / self.voxel_spacing, 0]).to(self.torch_device)
-        z_edge_voxels = torch.tensor([0, 0, z_edge_mm / self.voxel_spacing]).to(self.torch_device)
+        x_edge_voxels = torch.tensor([x_edge_mm / self.voxel_spacing, 0, 0],
+                                     dtype=torch.float, device=self.torch_device)
+        y_edge_voxels = torch.tensor([0, y_edge_mm / self.voxel_spacing, 0],
+                                     dtype=torch.float, device=self.torch_device)
+        z_edge_voxels = torch.tensor([0, 0, z_edge_mm / self.voxel_spacing],
+                                     dtype=torch.float, device=self.torch_device)
 
-        x, y, z = torch.meshgrid(torch.arange(self.volume_dimensions_voxels[0]).to(self.torch_device),
-                                 torch.arange(self.volume_dimensions_voxels[1]).to(self.torch_device),
-                                 torch.arange(self.volume_dimensions_voxels[2]).to(self.torch_device),
-                                 indexing='ij')
+        target_vector = torch.stack(torch.meshgrid(torch.arange(self.volume_dimensions_voxels[0], dtype=torch.float, device=self.torch_device),
+                                                   torch.arange(
+                                                       self.volume_dimensions_voxels[1], dtype=torch.float, device=self.torch_device),
+                                                   torch.arange(
+                                                       self.volume_dimensions_voxels[2], dtype=torch.float, device=self.torch_device),
+                                                   indexing='ij'), dim=-1)
 
-        target_vector = torch.subtract(torch.stack([x, y, z], axis=-1), start_voxels)
+        target_vector -= start_voxels
 
         matrix = torch.stack([x_edge_voxels, y_edge_voxels, z_edge_voxels])
 
         inverse_matrix = torch.linalg.inv(matrix)
 
+        print(target_vector.shape)
+        print(inverse_matrix.shape)
         result = torch.matmul(target_vector, inverse_matrix)
+        del target_vector
 
         norm_vector = torch.tensor([1/torch.linalg.norm(x_edge_voxels),
                                     1/torch.linalg.norm(y_edge_voxels),
-                                    1/torch.linalg.norm(z_edge_voxels)]).to(self.torch_device)
+                                    1/torch.linalg.norm(z_edge_voxels)], dtype=torch.float, device=self.torch_device)
 
         filled_mask_bool = (0 <= result) & (result <= 1 - norm_vector)
         border_bool = (0 - norm_vector < result) & (result <= 1)
 
-        volume_fractions = torch.zeros(tuple(self.volume_dimensions_voxels), dtype=torch.float).to(self.torch_device)
-        filled_mask = torch.all(filled_mask_bool, axis=-1)
+        volume_fractions = torch.zeros(tuple(self.volume_dimensions_voxels),
+                                       dtype=torch.float, device=self.torch_device)
+        filled_mask = torch.all(filled_mask_bool, dim=-1)
 
-        border_mask = torch.all(border_bool, axis=-1)
+        border_mask = torch.all(border_bool, dim=-1)
 
         border_mask = torch.logical_xor(border_mask, filled_mask)
 
@@ -102,7 +111,7 @@ class RectangularCuboidStructure(GeometricalStructure):
         fraction_values[fraction_values <= 0] = 1 + fraction_values[fraction_values <= 0]
         fraction_values[larger_fraction_values < 1] = larger_fraction_values[larger_fraction_values < 1]
 
-        fraction_values = torch.abs(torch.prod(fraction_values, axis=-1))
+        fraction_values = torch.abs(torch.prod(fraction_values, dim=-1))
 
         volume_fractions[filled_mask] = 1
         volume_fractions[border_mask] = fraction_values

--- a/simpa/utils/libraries/structure_library/StructureBase.py
+++ b/simpa/utils/libraries/structure_library/StructureBase.py
@@ -69,7 +69,7 @@ class GeometricalStructure:
         self.molecule_composition = single_structure_settings[Tags.MOLECULE_COMPOSITION]
         self.molecule_composition.update_internal_properties()
 
-        self.geometrical_volume = np.zeros(self.volume_dimensions_voxels)
+        self.geometrical_volume = np.zeros(self.volume_dimensions_voxels, dtype=np.float32)
         self.params = self.get_params_from_settings(single_structure_settings)
         self.fill_internal_volume()
 

--- a/simpa/utils/libraries/structure_library/__init__.py
+++ b/simpa/utils/libraries/structure_library/__init__.py
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: 2021 Janek Groehl
 # SPDX-License-Identifier: MIT
 
-import operator
 import traceback
-
+import torch
 from simpa.log import Logger
 from simpa.utils import Settings, Tags
 
@@ -26,38 +25,27 @@ from simpa.utils.libraries.structure_library.VesselStructure import VesselStruct
     define_vessel_structure_settings
 
 
-class Structures:
+def priority_sorted_structures(settings: Settings, volume_creator_settings: dict):
     """
-    TODO
+    A generator function to lazily construct structures in descending order of priority
     """
-
-    def __init__(self, settings: Settings, volume_creator_settings: dict):
-        """
-        TODO
-        """
-        self.logger = Logger()
-        self.structures = self.from_settings(settings, volume_creator_settings)
-        self.sorted_structures = sorted(self.structures, key=operator.attrgetter('priority'), reverse=True)
-
-    def from_settings(self, global_settings, volume_creator_settings):
-        structures = list()
-        if not Tags.STRUCTURES in volume_creator_settings:
-            self.logger.warning("Did not find any structure definitions in the settings file!")
-            return structures
-        _structure_settings = volume_creator_settings[Tags.STRUCTURES]
-        for struc_tag_name in _structure_settings:
-            single_structure_settings = _structure_settings[struc_tag_name]
-            try:
-                structure_class = globals()[single_structure_settings[Tags.STRUCTURE_TYPE]]
-                structure = structure_class(global_settings, single_structure_settings)
-                structures.append(structure)
-            except Exception as e:
-                self.logger.critical("An exception has occurred while trying to parse " +
-                                     str(single_structure_settings[Tags.STRUCTURE_TYPE]) +
-                                     " from the dictionary.")
-                self.logger.critical("The structure type was " + str(single_structure_settings[Tags.STRUCTURE_TYPE]))
-                self.logger.critical(traceback.format_exc())
-                self.logger.critical("trying to continue as normal...")
-                raise e
-
-        return structures
+    logger = Logger()
+    if not Tags.STRUCTURES in volume_creator_settings:
+        logger.warning("Did not find any structure definitions in the settings file!")
+        return
+    sorted_structure_settings = sorted(
+        [structure_setting for structure_setting in volume_creator_settings[Tags.STRUCTURES].values()],
+        key=lambda s: s[Tags.PRIORITY] if Tags.PRIORITY in s else 0, reverse=True)
+    for structure_setting in sorted_structure_settings:
+        try:
+            structure_class = globals()[structure_setting[Tags.STRUCTURE_TYPE]]
+            yield structure_class(settings, structure_setting)
+            torch.cuda.empty_cache()
+        except Exception as e:
+            logger.critical("An exception has occurred while trying to parse " +
+                            str(structure_setting[Tags.STRUCTURE_TYPE]) +
+                            " from the dictionary.")
+            logger.critical("The structure type was " + str(structure_setting[Tags.STRUCTURE_TYPE]))
+            logger.critical(traceback.format_exc())
+            logger.critical("trying to continue as normal...")
+            raise e

--- a/simpa_tests/automatic_tests/test_linear_unmixing.py
+++ b/simpa_tests/automatic_tests/test_linear_unmixing.py
@@ -81,7 +81,7 @@ class TestLinearUnmixing(unittest.TestCase):
         lu_results = sp.load_data_field(self.settings[Tags.SIMPA_OUTPUT_PATH], Tags.LINEAR_UNMIXING_RESULT)
         self.assert_correct_so2_vales(lu_results["sO2"])
 
-    def assert_correct_so2_vales(self, estimates, tolerance=1e-8):
+    def assert_correct_so2_vales(self, estimates, tolerance=1e-7):
         ground_truth = sp.load_data_field(self.settings[Tags.SIMPA_OUTPUT_PATH], Tags.DATA_FIELD_OXYGENATION)
         msg = f"expected {estimates.reshape((-1,))[0]} but was {ground_truth.reshape((-1,))[0]}"
         self.logger.info(msg)

--- a/simpa_tests/automatic_tests/tissue_library/test_tissue_library_against_literature_values.py
+++ b/simpa_tests/automatic_tests/tissue_library/test_tissue_library_against_literature_values.py
@@ -6,7 +6,7 @@ import unittest
 from simpa.utils import TISSUE_LIBRARY
 from simpa_tests.test_utils.tissue_composition_tests import compare_molecular_composition_against_expected_values, \
     get_epidermis_reference_dictionary, get_dermis_reference_dictionary, get_muscle_reference_dictionary, \
-    get_fully_oxygenated_blood_reference_dictionary,\
+    get_fully_oxygenated_blood_reference_dictionary, \
     get_fully_deoxygenated_blood_reference_dictionary, \
     get_lymph_node_reference_dictionary
 


### PR DESCRIPTION
- use gpu in `create_simulation_volume()` if available
- construct structures as needed instead of all at once
- empty cache between each structure to reduce GPU ram usage
- use float32 type throughout when constructing arrays
- increase allowed tolerance for so2 in test from 1e-8 to 1e-7 due to gpu float32 precision

 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [ ] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
Runtime of `create_simulation_volume()` in test script reduces from 30.5s -> 7.2s