### PR TITLE
removed gel_layer_height in simulate_3D.m

### DIFF
--- a/simpa/core/simulation_modules/acoustic_forward_module/simulate_3D.m
+++ b/simpa/core/simulation_modules/acoustic_forward_module/simulate_3D.m
@@ -100,7 +100,7 @@ karray = kWaveArray;
 
 elem_pos = data.sensor_element_positions/1000;
 
-elem_pos(1, :) = elem_pos(1, :) - 0.5 * kgrid.x_size + dx * GEL_LAYER_HEIGHT;
+elem_pos(1, :) = elem_pos(1, :) - 0.5 * kgrid.x_size;
 elem_pos(2, :) = elem_pos(2, :) - 0.5 * kgrid.y_size;
 elem_pos(3, :) = elem_pos(3, :) - 0.5 * kgrid.z_size;
 num_elements = size(elem_pos, 2);


### PR DESCRIPTION
 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [ ] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
 **Provide issue / feature request fixed by this PR**
 
 Fixes #237 

For now removed the gel_layer_height in the calculation of the element positions, because the gel layer is never padded to the arrays.
