### PR TITLE
Use gpu for noise generation if available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: check-added-large-files # prevents adding large files, above 500kB
 
 -   repo: https://github.com/pre-commit/mirrors-autopep8 # Uses MIT-License (MIT compatible) 
-    rev: v2.0.2  # Use the sha / tag you want to point at
+    rev: v2.0.4  # Use the sha / tag you want to point at
     hooks:
     -   id: autopep8 # formats code according to PEP8 standard. Lets commit fail if it needs to reformat code. Config for autopep8 is done in myproject.toml
 
@@ -17,7 +17,7 @@ repos:
       - id: validate-cff # validates cff citation files
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks # Uses MIT License (MIT compatible)
-  rev: v1.5.1
+  rev: v1.5.4
   hooks:
     - id: insert-license    # Checks if the license header specified at license_header.txt is added in the first lines of each python file. If not, it suggests to insert them.
       types: [python]
@@ -31,7 +31,7 @@ repos:
     -   id: gitlint
 
 -   repo: https://github.com/tcort/markdown-link-check # Uses ISC-License (MIT compatible) 
-    rev: v3.10.3
+    rev: v3.11.2
     hooks:
       - id: markdown-link-check # checks if links in markdown files work
         exclude: docs/

--- a/simpa/core/processing_components/__init__.py
+++ b/simpa/core/processing_components/__init__.py
@@ -4,6 +4,7 @@
 
 from abc import ABC
 from simpa.core import SimulationModule
+from simpa.utils.processing_device import get_processing_device
 
 
 class ProcessingComponent(SimulationModule, ABC):
@@ -19,3 +20,4 @@ class ProcessingComponent(SimulationModule, ABC):
         """
         super(ProcessingComponent, self).__init__(global_settings=global_settings)
         self.component_settings = global_settings[component_settings_key]
+        self.torch_device = get_processing_device(global_settings)

--- a/simpa/core/processing_components/monospectral/noise/gaussian_noise.py
+++ b/simpa/core/processing_components/monospectral/noise/gaussian_noise.py
@@ -8,6 +8,7 @@ from simpa.io_handling import load_data_field, save_data_field
 from simpa.core.processing_components import ProcessingComponent
 from simpa.utils.quality_assurance.data_sanity_testing import assert_array_well_defined
 import numpy as np
+import torch
 
 
 class GaussianNoise(ProcessingComponent):
@@ -56,17 +57,21 @@ class GaussianNoise(ProcessingComponent):
 
         wavelength = self.global_settings[Tags.WAVELENGTH]
         data_array = load_data_field(self.global_settings[Tags.SIMPA_OUTPUT_PATH], data_field, wavelength)
+        data_tensor = torch.as_tensor(data_array, dtype=torch.float32, device=self.torch_device)
+        dist = torch.distributions.normal.Normal(torch.tensor(mean, dtype=torch.float32, device=self.torch_device),
+                                                 torch.tensor(std, dtype=torch.float32, device=self.torch_device))
 
         if mode == Tags.NOISE_MODE_ADDITIVE:
-            data_array = data_array + np.random.normal(mean, std, size=np.shape(data_array))
+            data_tensor += dist.sample(data_tensor.shape)
         elif mode == Tags.NOISE_MODE_MULTIPLICATIVE:
-            data_array = data_array * np.random.normal(mean, std, size=np.shape(data_array))
+            data_tensor *= dist.sample(data_tensor.shape)
 
         if not (Tags.IGNORE_QA_ASSERTIONS in self.global_settings and Tags.IGNORE_QA_ASSERTIONS):
-            assert_array_well_defined(data_array)
+            assert_array_well_defined(data_tensor)
 
         if non_negative:
-            data_array[data_array < EPS] = EPS
-        save_data_field(data_array, self.global_settings[Tags.SIMPA_OUTPUT_PATH], data_field, wavelength)
+            data_tensor[data_tensor < EPS] = EPS
+        save_data_field(data_tensor.cpu().numpy().astype(np.float64, copy=False),
+                        self.global_settings[Tags.SIMPA_OUTPUT_PATH], data_field, wavelength)
 
         self.logger.info("Applying Gaussian Noise Model...[Done]")

--- a/simpa/core/processing_components/monospectral/noise/poisson_noise.py
+++ b/simpa/core/processing_components/monospectral/noise/poisson_noise.py
@@ -7,11 +7,12 @@ from simpa.io_handling import load_data_field, save_data_field
 from simpa.core.processing_components import ProcessingComponent
 from simpa.utils.quality_assurance.data_sanity_testing import assert_array_well_defined
 import numpy as np
+import torch
 
 
 class PoissonNoise(ProcessingComponent):
     """
-    Applies Gaussian noise to the defined data field.
+    Applies Poisson noise to the defined data field.
     The noise will be applied to all wavelengths.
 
     Component Settings::
@@ -44,15 +45,18 @@ class PoissonNoise(ProcessingComponent):
 
         wavelength = self.global_settings[Tags.WAVELENGTH]
         data_array = load_data_field(self.global_settings[Tags.SIMPA_OUTPUT_PATH], data_field, wavelength)
+        data_tensor = torch.as_tensor(data_array, dtype=torch.float32, device=self.torch_device)
+        dist = torch.distributions.poisson.Poisson(torch.tensor(mean, dtype=torch.float32, device=self.torch_device))
 
         if mode == Tags.NOISE_MODE_ADDITIVE:
-            data_array = data_array + np.random.poisson(mean, size=np.shape(data_array))
+            data_tensor += dist.sample(data_tensor.shape)
         elif mode == Tags.NOISE_MODE_MULTIPLICATIVE:
-            data_array = data_array * np.random.poisson(mean, size=np.shape(data_array))
+            data_tensor *= dist.sample(data_tensor.shape)
 
         if not (Tags.IGNORE_QA_ASSERTIONS in self.global_settings and Tags.IGNORE_QA_ASSERTIONS):
-            assert_array_well_defined(data_array)
+            assert_array_well_defined(data_tensor)
 
-        save_data_field(data_array, self.global_settings[Tags.SIMPA_OUTPUT_PATH], data_field, wavelength)
+        save_data_field(data_tensor.cpu().numpy().astype(np.float64, copy=False),
+                        self.global_settings[Tags.SIMPA_OUTPUT_PATH], data_field, wavelength)
 
         self.logger.info("Applying Poisson Noise Model...[Done]")

--- a/simpa/utils/quality_assurance/data_sanity_testing.py
+++ b/simpa/utils/quality_assurance/data_sanity_testing.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 import numpy as np
+import torch
 import inspect
+from typing import Union
 
 
 def assert_equal_shapes(numpy_arrays: list):
@@ -29,13 +31,13 @@ def assert_equal_shapes(numpy_arrays: list):
                              f" parameters. Called from {inspect.stack()[1].function}")
 
 
-def assert_array_well_defined(array: np.ndarray, assume_non_negativity: bool = False,
+def assert_array_well_defined(array: Union[np.ndarray, torch.Tensor], assume_non_negativity: bool = False,
                               assume_positivity=False, array_name: str = None):
     """
-    This method tests if all entries of the given array are well-defined (i.e. not np.inf, np.nan, or None).
+    This method tests if all entries of the given array or tensor are well-defined (i.e. not np.inf, np.nan, or None).
     The method can be parametrised to be more strict.
 
-    :param array: The input np.ndarray
+    :param array: The input np.ndarray or torch.Tensor
     :param assume_non_negativity: bool (default: False). If true, all values must be greater than or equal to 0.
     :param assume_positivity: bool (default: False). If true, all values must be greater than 0.
     :param array_name: a string that gives more information in case of an error.
@@ -43,11 +45,12 @@ def assert_array_well_defined(array: np.ndarray, assume_non_negativity: bool = F
     """
 
     error_message = None
-    if not np.isfinite(array).all():
+    array_as_tensor = torch.as_tensor(array)
+    if not torch.all(torch.isfinite(array_as_tensor)):
         error_message = "nan, inf or -inf"
-    if assume_positivity and (array <= 0).any():
+    if assume_positivity and torch.any(array_as_tensor <= 0):
         error_message = "not positive"
-    if assume_non_negativity and (array < 0).any():
+    if assume_non_negativity and torch.any(array_as_tensor < 0):
         error_message = "negative"
     if error_message:
         if array_name is None:

--- a/simpa_tests/automatic_tests/test_noise_models.py
+++ b/simpa_tests/automatic_tests/test_noise_models.py
@@ -5,6 +5,7 @@
 import unittest
 import os
 import numpy as np
+import torch
 
 from simpa.core.processing_components.monospectral.noise import *
 from simpa.utils import Tags, Settings
@@ -32,6 +33,7 @@ class TestNoiseModels(unittest.TestCase):
                                      expected_mean, expected_std,
                                      error_margin=0.05):
         np.random.seed(self.RANDOM_SEED)
+        torch.manual_seed(self.RANDOM_SEED)
 
         settings = {
             # These parameters set the general propeties of the simulated volume
@@ -78,7 +80,7 @@ class TestNoiseModels(unittest.TestCase):
                             f"The mean was not as expected. Expected {expected_mean} but was {actual_mean}")
             self.assertTrue(np.abs(actual_std - expected_std) < 1e-10 or
                             np.abs(actual_std - expected_std) / expected_std < error_margin,
-                            f"The mean was not as expected. Expected {expected_std} but was {actual_std}")
+                            f"The std was not as expected. Expected {expected_std} but was {actual_std}")
         finally:
             if (os.path.exists(settings[Tags.SIMPA_OUTPUT_PATH]) and
                     os.path.isfile(settings[Tags.SIMPA_OUTPUT_PATH])):
@@ -87,8 +89,8 @@ class TestNoiseModels(unittest.TestCase):
 
     def setUp(self):
 
-        self.VOLUME_WIDTH_IN_MM = 10
-        self.VOLUME_HEIGHT_IN_MM = 10
+        self.VOLUME_WIDTH_IN_MM = 20
+        self.VOLUME_HEIGHT_IN_MM = 20
         self.SPACING = 1
         self.RANDOM_SEED = 4711
 

--- a/simpa_tests/automatic_tests/test_noise_models.py
+++ b/simpa_tests/automatic_tests/test_noise_models.py
@@ -89,8 +89,8 @@ class TestNoiseModels(unittest.TestCase):
 
     def setUp(self):
 
-        self.VOLUME_WIDTH_IN_MM = 20
-        self.VOLUME_HEIGHT_IN_MM = 20
+        self.VOLUME_WIDTH_IN_MM = 40
+        self.VOLUME_HEIGHT_IN_MM = 40
         self.SPACING = 1
         self.RANDOM_SEED = 4711
 


### PR DESCRIPTION
- `assert_array_well_defined` now accepts array or tensor
  - if the tensor is already on the gpu the assertions will also be done on the gpu
- increase number of noise samples in tests to make the statistical tests more robust
- convert final arrays back to float64 to maintain existing data format
  - these conversions can be removed when the simpy array datatype is changed to float32

 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [ ] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
 **List any specific code review questions**
  
 **List any special testing requirements**
 
 **Additional context (e.g. papers, documentation, blog posts, ...)**
  
 **Provide issue / feature request fixed by this PR**
 
 Fixes #<ISSUE NUMBER>
