### PR TITLE
Use mcx SLIT source for MSOTAcuity and MSOTInvision sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,25 +75,13 @@ acoustic simulations possible.
 
 ### mcx (Optical Forward Model)
 
-Either download suitable executables or build yourself from the following sources:
+Download the latest nightly build of [mcx](http://mcx.space/) for your operating system:
 
-[http://mcx.space/](http://mcx.space/)
+- [Linux](http://mcx.space/nightly/github/mcx-linux-x64-github-latest.zip)
+- [MacOS](http://mcx.space/nightly/github/mcx-macos-x64-github-latest.zip)
+- [Windows](http://mcx.space/nightly/github/mcx-windows-x64-github-latest.zip)
 
-In order to obtain access to all custom sources that we implemented, please build mcx yourself from the
-following mcx Github fork:
-[https://github.com/IMSY-DKFZ/mcx](https://github.com/IMSY-DKFZ/mcx)
-
-For the installation, please follow steps 1-4:
-1. `git clone https://github.com/IMSY-DKFZ/mcx.git`
-2. `cd mcx/src`
-3. In `MAKEFILE` adapt line 111 the sm version [according to your GPU](https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/).
-4. `make`
-
-The built binary can be found in `src/bin`.
-Note, in case you can’t build mcx with the GPU-specific sm version you need to install a more recent NVIDIA driver and nvcc toolkit. 
-One option would be to install cuda in a conda environment via `conda install cuda -c nvidia`.
-Please note that there might be compatibility issues using mcx-cl with the MCX Adapter as this use case is not 
-being tested and supported by the SIMPA developers.
+Then extract the files and set `MCX_BINARY_PATH=/.../mcx/bin/mcx` in your path_config.env.
 
 ### k-Wave (Acoustic Forward Model)
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -39,25 +39,13 @@ acoustic simulations possible.
 
 ### mcx (Optical Forward Model)
 
-Either download suitable executables or build yourself from the following sources:
+Download the latest nightly build of [mcx](http://mcx.space/) for your operating system:
 
-[http://mcx.space/](http://mcx.space/)
+- [Linux](http://mcx.space/nightly/github/mcx-linux-x64-github-latest.zip)
+- [MacOS](http://mcx.space/nightly/github/mcx-macos-x64-github-latest.zip)
+- [Windows](http://mcx.space/nightly/github/mcx-windows-x64-github-latest.zip)
 
-In order to obtain access to all custom sources that we implemented, please build mcx yourself from the
-following mcx Github fork:
-[https://github.com/IMSY-DKFZ/mcx](https://github.com/IMSY-DKFZ/mcx)
-
-For the installation, please follow steps 1-4:
-1. `git clone https://github.com/IMSY-DKFZ/mcx.git`
-2. `cd mcx/src`
-3. In `MAKEFILE` adapt line 111 the sm version [according to your GPU](https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/).
-4. `make`
-
-The built binary can be found in `src/bin`.
-Note, in case you can’t build mcx with the GPU-specific sm version you need to install a more recent NVIDIA driver and nvcc toolkit. 
-One option would be to install cuda in a conda environment via `conda install cuda -c nvidia`.
-Please note that there might be compatibility issues using mcx-cl with the MCX Adapter as this use case is not 
-being tested and supported by the SIMPA developers.
+Then extract the files and set `MCX_BINARY_PATH=/.../mcx/bin/mcx` in your path_config.env.
 
 ### k-Wave (Acoustic Forward Model)
 

--- a/simpa/core/device_digital_twins/digital_device_twin_base.py
+++ b/simpa/core/device_digital_twins/digital_device_twin_base.py
@@ -12,6 +12,15 @@ import uuid
 from simpa.utils.serializer import SerializableSIMPAClass
 
 
+def is_equal(a, b) -> bool:
+    if isinstance(a, list):
+        return all(is_equal(ai, bi) for ai, bi in zip(a, b))
+    elif isinstance(a, np.ndarray):
+        return (a == b).all
+    else:
+        return a == b
+
+
 class DigitalDeviceTwinBase(SerializableSIMPAClass):
     """
     This class represents a device that can be used for illumination, detection or a combined photoacoustic device
@@ -49,14 +58,8 @@ class DigitalDeviceTwinBase(SerializableSIMPAClass):
                 return False
             for self_key, self_value in self.__dict__.items():
                 other_value = other.__dict__[self_key]
-                if isinstance(self_value, np.ndarray):
-                    boolean = (other_value != self_value).all()
-                else:
-                    boolean = other_value != self_value
-                if boolean:
+                if not is_equal(self_value, other_value):
                     return False
-                else:
-                    continue
             return True
         return False
 

--- a/simpa/core/device_digital_twins/illumination_geometries/ithera_msot_acuity_illumination.py
+++ b/simpa/core/device_digital_twins/illumination_geometries/ithera_msot_acuity_illumination.py
@@ -29,21 +29,25 @@ class MSOTAcuityIlluminationGeometry(IlluminationGeometryBase):
         self.normalized_source_direction_vector = self.source_direction_vector / np.linalg.norm(
             self.source_direction_vector)
 
-    def get_mcx_illuminator_definition(self, global_settings: Settings):
+        divergence_angle = 8.66  # full beam divergence angle measured at Full Width at Half Maximum (FWHM)
+        full_width_at_half_maximum = 2.0 * np.tan(0.5 * np.deg2rad(divergence_angle))  # FWHM of beam divergence
+        # standard deviation of gaussian with FWHM
+        self.sigma = full_width_at_half_maximum / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
-        source_type = Tags.ILLUMINATION_TYPE_MSOT_ACUITY_ECHO
+    def get_mcx_illuminator_definition(self, global_settings: Settings):
+        source_type = Tags.ILLUMINATION_TYPE_SLIT
         spacing = global_settings[Tags.SPACING_MM]
         device_position = list(self.device_position_mm / spacing + 0.5)
-
+        device_length = 30 / spacing
+        source_pos = device_position
+        source_pos[0] -= 0.5 * device_length
         source_direction = list(self.normalized_source_direction_vector)
-
-        source_param1 = [30 / spacing, 0, 0, 0]
-
-        source_param2 = [0, 0, 0, 0]
+        source_param1 = [device_length, 0.0, 0.0, 0.0]
+        source_param2 = [self.sigma, self.sigma, 0.0, 0.0]
 
         return {
             "Type": source_type,
-            "Pos": device_position,
+            "Pos": source_pos,
             "Dir": source_direction,
             "Param1": source_param1,
             "Param2": source_param2

--- a/simpa/core/device_digital_twins/pa_devices/ithera_msot_invision.py
+++ b/simpa/core/device_digital_twins/pa_devices/ithera_msot_invision.py
@@ -54,9 +54,7 @@ class InVision256TF(PhotoacousticDevice):
 
         self.field_of_view_extent_mm = detection_geometry.field_of_view_extent_mm
         self.set_detection_geometry(detection_geometry)
-        for i in range(10):
-            self.add_illumination_geometry(MSOTInVisionIlluminationGeometry(invision_position=self.device_position_mm,
-                                                                            geometry_id=i))
+        self.add_illumination_geometry(MSOTInVisionIlluminationGeometry(invision_position=self.device_position_mm))
 
     def serialize(self) -> dict:
         serialized_device = self.__dict__

--- a/simpa/core/simulation_modules/optical_simulation_module/optical_forward_model_mcx_reflectance_adapter.py
+++ b/simpa/core/simulation_modules/optical_simulation_module/optical_forward_model_mcx_reflectance_adapter.py
@@ -101,6 +101,9 @@ class MCXAdapterReflectance(MCXAdapter):
         cmd.append(self.mcx_json_config_file)
         cmd.append("-O")
         cmd.append("F")
+        # use 'C' order array format for binary input file
+        cmd.append("-a")
+        cmd.append("1")
         cmd.append("-F")
         cmd.append("jnii")
         if Tags.COMPUTE_PHOTON_DIRECTION_AT_EXIT in self.component_settings and \
@@ -128,6 +131,9 @@ class MCXAdapterReflectance(MCXAdapter):
                 self.mcx_output_suffixes['mcx_volumetric_data_file']):
             content = jdata.load(self.mcx_volumetric_data_file)
             fluence = content['NIFTIData']
+            if fluence.ndim > 3:
+                # mcx >= v2024.1 includes additional dimensions in this data structure for the source and detector ids
+                fluence = np.squeeze(fluence)
             ref, ref_pos, fluence = self.extract_reflectance_from_fluence(fluence=fluence)
             fluence = self.post_process_volumes(**{'arrays': (fluence,)})[0]
             fluence *= 100  # Convert from J/mm^2 to J/cm^2

--- a/simpa/core/simulation_modules/optical_simulation_module/optical_forward_model_mcx_reflectance_adapter.py
+++ b/simpa/core/simulation_modules/optical_simulation_module/optical_forward_model_mcx_reflectance_adapter.py
@@ -18,8 +18,8 @@ class MCXAdapterReflectance(MCXAdapter):
     diffuse reflectance simulations. Specifically, it implements the capability to run diffuse reflectance simulations.
 
     .. warning::
-        This MCX adapter requires a version of MCX containing the revision: `Rev::077060`, which was published in the
-        Nightly build  on `2022-01-26`.
+        This MCX adapter requires a version of MCX containing the commit 56eca8ae7e9abde309053759d6d6273ac4795fc5,
+        which was published in the Nightly build on `2024-03-10`.
 
     .. note::
         MCX is a GPU-enabled Monte-Carlo model simulation of photon transport in tissue:

--- a/simpa/core/simulation_modules/optical_simulation_module/optical_forward_model_mcx_reflectance_adapter.py
+++ b/simpa/core/simulation_modules/optical_simulation_module/optical_forward_model_mcx_reflectance_adapter.py
@@ -132,8 +132,8 @@ class MCXAdapterReflectance(MCXAdapter):
             content = jdata.load(self.mcx_volumetric_data_file)
             fluence = content['NIFTIData']
             if fluence.ndim > 3:
-                # mcx >= v2024.1 includes additional dimensions in this data structure for the source and detector ids
-                fluence = np.squeeze(fluence)
+                # remove the 1 or 2 (for mcx >= v2024.1) additional dimensions of size 1 if present to obtain a 3d array
+                fluence = fluence.reshape(fluence.shape[0], fluence.shape[1], -1)
             ref, ref_pos, fluence = self.extract_reflectance_from_fluence(fluence=fluence)
             fluence = self.post_process_volumes(**{'arrays': (fluence,)})[0]
             fluence *= 100  # Convert from J/mm^2 to J/cm^2

--- a/simpa/utils/quality_assurance/data_sanity_testing.py
+++ b/simpa/utils/quality_assurance/data_sanity_testing.py
@@ -45,7 +45,11 @@ def assert_array_well_defined(array: Union[np.ndarray, torch.Tensor], assume_non
     """
 
     error_message = None
-    array_as_tensor = torch.as_tensor(array)
+    if isinstance(array, np.ndarray) and any(stride < 0 for stride in array.strides):
+        # torch does not support tensors with negative strides so we need to make a copy of the array
+        array_as_tensor = torch.as_tensor(array.copy())
+    else:
+        array_as_tensor = torch.as_tensor(array)
     if not torch.all(torch.isfinite(array_as_tensor)):
         error_message = "nan, inf or -inf"
     if assume_positivity and torch.any(array_as_tensor <= 0):


### PR DESCRIPTION
 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [x] Did you run manual tests?
- [ ] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
 **List any specific code review questions**
  
 **List any special testing requirements**
 
Requires mcx version >= v2024.2

 **Additional context (e.g. papers, documentation, blog posts, ...)**
  
 **Provide issue / feature request fixed by this PR**
 
- MSOTAcuityIlluminationGeometry
  - Change in source due to fixing of sign error
- MSOTInVisionIlluminationGeometry
  - Change in source due to use of gaussian broadening instead of step function
  - Now only requires a single mcx run using the new multiple sources feature
- Note: requires mcx version >= v2024.2
