### PR TITLE
raise valueerror if interpolated wavelengths are out of range and wri…

### DIFF
--- a/simpa/utils/libraries/spectrum_library.py
+++ b/simpa/utils/libraries/spectrum_library.py
@@ -13,7 +13,7 @@ from simpa.utils.serializer import SerializableSIMPAClass
 
 class Spectrum(SerializableSIMPAClass, object):
     """
-    An instance of this class represents the absorption spectrum over wavelength for a particular
+    An instance of this class represents a spectrum over a range of wavelengths. 
     """
 
     def __init__(self, spectrum_name: str, wavelengths: np.ndarray, values: np.ndarray):
@@ -29,25 +29,29 @@ class Spectrum(SerializableSIMPAClass, object):
         self.values = values
 
         if np.shape(wavelengths) != np.shape(values):
-            raise ValueError("The shape of the wavelengths and the absorption coefficients did not match: " +
+            raise ValueError("The shape of the wavelengths and the values did not match: " +
                              str(np.shape(wavelengths)) + " vs " + str(np.shape(values)))
 
         new_wavelengths = np.arange(self.min_wavelength, self.max_wavelength+1, 1)
-        self.new_absorptions = np.interp(new_wavelengths, self.wavelengths, self.values)
+        self.values_interp = np.interp(new_wavelengths, self.wavelengths, self.values)
 
     def get_value_over_wavelength(self):
         """
-        :return: numpy array with the available wavelengths and the corresponding absorption properties
+        :return: numpy array with the available wavelengths and the corresponding properties
         """
         return np.asarray([self.wavelengths, self.values])
 
     def get_value_for_wavelength(self, wavelength: int) -> float:
         """
-        :param wavelength: the wavelength to retrieve a optical absorption value for [cm^{-1}].
+        :param wavelength: the wavelength to retrieve a value from the defined spectrum.
                            Must be an integer value between the minimum and maximum wavelength.
-        :return: the best matching linearly interpolated absorption value for the given wavelength.
+        :return: the best matching linearly interpolated values for the given wavelength.
+        :raises ValueError: if the given wavelength is not within the range of the spectrum.
         """
-        return self.new_absorptions[wavelength-self.min_wavelength]
+        if wavelength < self.min_wavelength or wavelength > self.max_wavelength:
+            raise ValueError(f"The given wavelength ({wavelength}) is not within the range of the spectrum "
+                             f"({self.min_wavelength} - {self.max_wavelength})")
+        return self.values_interp[wavelength-self.min_wavelength]
 
     def __eq__(self, other):
         if isinstance(other, Spectrum):


### PR DESCRIPTION
…te write documentation more generic
- add error handling if the wavelength for the `get_value_for_wavelength` function is smaller or larger than the provided min/max wavelengths
- There were some specific references to absorption. However, the class is more general and also handles scattering and anisotropy. We therefore wrote the documentation more generic. 
 
 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [ ] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?
  
 **Provide issue / feature request fixed by this PR**
 
 Fixes #221 
