### PR TITLE
The Rayleigh Scattering is not correct.

### DIFF
--- a/simpa/utils/libraries/spectrum_library.py
+++ b/simpa/utils/libraries/spectrum_library.py
@@ -247,7 +247,7 @@ class ScatteringSpectrumLibrary(SpectraLibrary):
         :return: A Spectrum instance based on Rayleigh and Mie scattering theory.
         """
         wavelengths = np.arange(450, 1001, 1)
-        scattering = (mus_at_500_nm * (fraction_rayleigh_scattering * (wavelengths / 500) ** 1e-4 +
+        scattering = (mus_at_500_nm * (fraction_rayleigh_scattering * (wavelengths / 500) ** (-4) +
                       (1 - fraction_rayleigh_scattering) * (wavelengths / 500) ** -mie_power_law_coefficient))
         return Spectrum(name, wavelengths, scattering)
 


### PR DESCRIPTION
Your formula for Rayleigh scattering used to be ~ (lambda) ^ (1e-4), but should be ~ (lambda)^-4

I put the pull request in by just editing the GitHub text file, so haven't rerun the tests, but I can't see why this should break anything. If you have any optical tests that validate light fluence values etc, then these will need remaking I suspect. 