### PR TITLE
T416 update acuity echo device parameters

### DIFF
--- a/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
+++ b/simpa/core/device_digital_twins/pa_devices/ithera_msot_acuity.py
@@ -72,7 +72,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
                                                           detector_element_width_mm=0.24,
                                                           detector_element_length_mm=13,
                                                           center_frequency_hz=3.96e6,
-                                                          bandwidth_percent=55,
+                                                          bandwidth_percent=153,
                                                           sampling_frequency_mhz=40,
                                                           angular_origin_offset=np.pi,
                                                           device_position_mm=self.detection_geometry_position_vector,
@@ -83,8 +83,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
 
         # y position relative to the membrane:
         # The laser is located 43.2 mm  behind the membrane with an angle of 22.4 degrees.
-        # However, the incident of laser and image plane is located 2.8 behind the membrane (outside of the device).
-        y_pos_relative_to_membrane = np.tan(np.deg2rad(22.4)) * (43.2 + 2.8)
+        y_pos_relative_to_membrane = np.tan(np.deg2rad(22.4)) * 43.2
         self.add_illumination_geometry(illumination_geometry,
                                        illuminator_position_relative_to_pa_device=np.array([0,
                                                                                             -y_pos_relative_to_membrane,
@@ -202,7 +201,7 @@ class MSOTAcuityEcho(PhotoacousticDevice):
                                                           detector_element_width_mm=0.24,
                                                           detector_element_length_mm=13,
                                                           center_frequency_hz=3.96e6,
-                                                          bandwidth_percent=55,
+                                                          bandwidth_percent=153,
                                                           sampling_frequency_mhz=40,
                                                           angular_origin_offset=np.pi,
                                                           device_position_mm=self.detection_geometry_position_vector,

--- a/simpa/core/processing_components/monospectral/field_of_view_cropping.py
+++ b/simpa/core/processing_components/monospectral/field_of_view_cropping.py
@@ -20,10 +20,7 @@ class FieldOfViewCropping(ProcessingComponentBase):
                 + [Tags.DATA_FIELD_FLUENCE, Tags.DATA_FIELD_INITIAL_PRESSURE]})
         super(FieldOfViewCropping, self).__init__(global_settings, "FieldOfViewCropping")
     """
-    Applies Gaussian noise to the defined data field.
-    The noise will be applied to all wavelengths.
-    Component Settings
-       **Tags.DATA_FIELD required
+    Crops all specified data fields to the field of view of the given device.
     """
 
     def run(self, device: DigitalDeviceTwinBase):

--- a/simpa/core/simulation_modules/acoustic_module/simulate_2D.m
+++ b/simpa/core/simulation_modules/acoustic_module/simulate_2D.m
@@ -84,7 +84,7 @@ estimated_cfl_number = dt / dx * mean(medium.sound_speed, 'all');
 disp(estimated_cfl_number);
 
 % smaller time steps are better for numerical stability in time progressing simulations
-% A minimum CFL of 0.3 is advised in the kwave handbook.
+% A maximum CFL of 0.3 is advised in the kwave handbook.
 % In case we specify something larger, we use a higher sampling rate than anticipated.
 % Otherwise we simulate with the target sampling rate
 if estimated_cfl_number < 0.3


### PR DESCRIPTION
 **Please check the following before creating the pull request (PR):**
- [x] Did you run automatic tests?
- [x] Did you run manual tests?
- [x] Is the code provided in the PR still backwards compatible to previous SIMPA versions?

Hi,
updates to the ithera acuity echo device, as mentioned by Jeremie in #416 and #419:
- Adjusted bandwidth in ithera msot acuity echo to 153%.
- removed offset from `y_pos_relative_to_membrane`.


Also included minor changes to some comments (described in #414 and #415)
 
 Fixes #416, #419, #414, #415 
